### PR TITLE
Security: Sanitize flash keys in HTML output

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
       <article>
         <% flash.each do |key, value| %>
           <aside>
-            <p class="flash <%= key %>"><%= value %></p>
+            <p class="flash <%= key.to_s.gsub(/[^a-z_-]/, '') %>"><%= value %></p>
           </aside>
         <% end %>
 


### PR DESCRIPTION
Prevents XSS by sanitizing flash keys before interpolation in HTML class attribute.

## Changes
- Modified flash rendering in `app/views/layouts/application.html.erb`
- Strip non-alphanumeric characters from flash keys using regex
- Only allows lowercase letters, underscores, and hyphens in class names

## Security Impact
**HIGH** - Prevents potential XSS attack via malicious flash keys. While flash keys are typically controlled by the application (:notice, :alert, :error), this adds defense-in-depth against attribute-context XSS.

## Example
Before: `<p class="flash <%= key %>">`
After: `<p class="flash <%= key.to_s.gsub(/[^a-z_-]/, '') %>">`

Normal flash keys like :notice, :alert work exactly as before. Malicious keys would be sanitized.