### PR TITLE
Fix: Volume mount paths in deploy config

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -76,8 +76,8 @@ aliases:
 #
 volumes:
   - "/home/app_storage/journal_administration/storage:/rails/storage"
-  - "home/app_storage/journal_administration/db:/app/db"
-  - "home/app_storage/journal_administration/storage:/app/storage"
+  - "/home/app_storage/journal_administration/db:/app/db"
+  - "/home/app_storage/journal_administration/storage:/app/storage"
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.


### PR DESCRIPTION
Adds missing leading slashes to volume mount paths in deploy.yml to ensure absolute paths.

## Changes
- Line 79: `home/app_storage/...` → `/home/app_storage/...`
- Line 80: `home/app_storage/...` → `/home/app_storage/...`

## Issue
Volume mount paths without leading slashes are treated as relative paths, which can cause:
- Deployment failures
- Unexpected file system behavior
- Data persistence issues

## Verification
```bash
bin/kamal config  # Should show no errors
```

All volume mounts now use absolute paths as intended.