### PR TITLE
Add OSAASY license

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -2,6 +2,8 @@ version: "0.2"
 language: en
 words:
   # Add project-specific terms, acronyms, or Railsisms here
+  - Osaasy
+  - O'Saasy
   - Rakefile
   - ActiveRecord
   - ActiveSupport

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,10 @@
+# O'Saasy License Agreement
+
+Copyright © 2026, Etienne van Delden-De la Haije.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+2. No licensee or downstream recipient may use the Software (including any modified or derivative versions) to directly compete with the original Licensor by offering it to third parties as a hosted, managed, or Software-as-a-Service (SaaS) product or cloud service where the primary value of the service is the functionality of the Software itself.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
- Adds the O'Saasy License Agreement to the project
- License allows free use, modification, and distribution while prohibiting direct SaaS competition
- Copyright holder updated to Etienne van Delden-De la Haije (2026)
- Added 'O'Saasy' to spell check configuration to recognize the license name

🤖 Generated with [Claude Code](https://claude.com/claude-code)