### PR TITLE
Fix Propshaft CSS loading with url() syntax

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,6 +1,6 @@
 /* MVPA.css framework - provides base styles, components, themes */
-@import "mvpa/mvpa.css";
+@import url("mvpa/mvpa.css");
 
 /* Local customizations (SMACSS structure) - load after MVPA to override */
-@import "local/layout/_index.css";
-@import "local/modules/_index.css";
+@import url("local/layout/index.css");
+@import url("local/modules/index.css");

--- a/app/assets/stylesheets/local/layout/_index.css
+++ b/app/assets/stylesheets/local/layout/_index.css
@@ -1,3 +1,0 @@
-@import "main_navigation.css";
-@import "application_page.css";
-@import "horizontal_rules.css";

--- a/app/assets/stylesheets/local/layout/index.css
+++ b/app/assets/stylesheets/local/layout/index.css
@@ -1,0 +1,3 @@
+@import url("main_navigation.css");
+@import url("application_page.css");
+@import url("horizontal_rules.css");

--- a/app/assets/stylesheets/local/modules/_index.css
+++ b/app/assets/stylesheets/local/modules/_index.css
@@ -1,3 +1,0 @@
-@import "buttons.css";
-@import "pagy.css";
-@import "form_errors.css";

--- a/app/assets/stylesheets/local/modules/index.css
+++ b/app/assets/stylesheets/local/modules/index.css
@@ -1,0 +1,3 @@
+@import url("buttons.css");
+@import url("pagy.css");
+@import url("form_errors.css");


### PR DESCRIPTION
## Summary

Fixed Propshaft CSS loading issues by:
- Renaming underscore-prefixed CSS partials (`_index.css` → `index.css`) since Propshaft doesn't understand Sass/Sprockets conventions
- Updating all `@import` statements to use `url()` syntax so Propshaft's CSS compiler can rewrite them to digested asset paths

Propshaft only serves digested assets and requires `@import url("...")` for the compiler to detect and rewrite asset references at serve-time.