### PR TITLE
Add admin dashboard and user management

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,11 @@
+class Admin::BaseController < ApplicationController
+  layout "admin"
+
+  before_action :ensure_admin
+
+  private
+
+  def ensure_admin
+    redirect_to root_path, alert: t("errors.admin_required") unless Current.user&.administrator?
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,7 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+    @users = User.all.order(created_at: :desc).limit(10)
+    @total_users = User.count
+    @admin_users = User.administrator.count
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,54 @@
+class Admin::UsersController < Admin::BaseController
+  before_action :set_user, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @users = User.all.order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_user_path(@user), notice: t(".success")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), notice: t(".success")
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @user == Current.user
+      redirect_to admin_users_path, alert: t(".cannot_delete_self")
+    else
+      @user.destroy
+      redirect_to admin_users_path, notice: t(".success")
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email_address, :role, :password, :password_confirmation)
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,42 @@
+<h1><%= t(".title") %></h1>
+
+<section>
+  <h2><%= t(".summary") %></h2>
+  <dl>
+    <dt><%= t(".total_users") %></dt>
+    <dd><%= @total_users %></dd>
+
+    <dt><%= t(".admin_users") %></dt>
+    <dd><%= @admin_users %></dd>
+  </dl>
+</section>
+
+<section>
+  <h2><%= t(".recent_signups") %></h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th><%= t(".name") %></th>
+        <th><%= t(".email") %></th>
+        <th><%= t(".role") %></th>
+        <th><%= t(".created_at") %></th>
+        <th><%= t(".actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td><%= user.name %></td>
+          <td><%= user.email_address %></td>
+          <td><%= user.role %></td>
+          <td><%= l(user.created_at, format: :long) %></td>
+          <td>
+            <%= link_to t(".view"), admin_user_path(user) %>
+            <%= link_to t(".edit"), edit_admin_user_path(user) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with model: user, url: url do |form| %>
+  <% if user.errors.any? %>
+    <aside role="alert">
+      <h2><%= t("errors.template.header", count: user.errors.count) %></h2>
+      <ul>
+        <% user.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </aside>
+  <% end %>
+
+  <fieldset>
+    <label for="user_name"><%= t(".name") %></label>
+    <%= form.text_field :name %>
+
+    <label for="user_email_address"><%= t(".email") %></label>
+    <%= form.email_field :email_address, required: true %>
+
+    <label for="user_role"><%= t(".role") %></label>
+    <%= form.select :role, User.roles.keys.map { |r| [r, r] }, {}, required: true %>
+
+    <label for="user_password"><%= t(".password") %></label>
+    <%= form.password_field :password, required: user.new_record? %>
+
+    <label for="user_password_confirmation"><%= t(".password_confirmation") %></label>
+    <%= form.password_field :password_confirmation, required: user.new_record? %>
+  </fieldset>
+
+  <nav>
+    <%= form.submit submit_label %>
+    <%= link_to t(".cancel"), cancel_path %>
+  </nav>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,7 @@
+<h1><%= t(".title") %></h1>
+
+<%= render "form",
+           user: @user,
+           url: admin_user_path(@user),
+           submit_label: t(".submit"),
+           cancel_path: admin_user_path(@user) %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,30 @@
+<h1><%= t(".title") %></h1>
+
+<p><%= link_to t(".new_user"), new_admin_user_path %></p>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= t(".name") %></th>
+      <th><%= t(".email") %></th>
+      <th><%= t(".role") %></th>
+      <th><%= t(".created_at") %></th>
+      <th><%= t(".actions") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.name %></td>
+        <td><%= user.email_address %></td>
+        <td><%= user.role %></td>
+        <td><%= l(user.created_at, format: :long) %></td>
+        <td>
+          <%= link_to t(".view"), admin_user_path(user) %>
+          <%= link_to t(".edit"), edit_admin_user_path(user) %>
+          <%= button_to t(".delete"), admin_user_path(user), method: :delete, data: { turbo_confirm: t(".confirm_delete") } unless user == Current.user %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,7 @@
+<h1><%= t(".title") %></h1>
+
+<%= render "form",
+           user: @user,
+           url: admin_users_path,
+           submit_label: t(".submit"),
+           cancel_path: admin_users_path %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,23 @@
+<h1><%= t(".title") %></h1>
+
+<dl>
+  <dt><%= t(".name") %></dt>
+  <dd><%= @user.name %></dd>
+
+  <dt><%= t(".email") %></dt>
+  <dd><%= @user.email_address %></dd>
+
+  <dt><%= t(".role") %></dt>
+  <dd><%= @user.role %></dd>
+
+  <dt><%= t(".created_at") %></dt>
+  <dd><%= l(@user.created_at, format: :long) %></dd>
+
+  <dt><%= t(".active_sessions") %></dt>
+  <dd><%= @user.sessions.count %></dd>
+</dl>
+
+<nav>
+  <%= link_to t(".edit"), edit_admin_user_path(@user) %>
+  <%= link_to t(".back"), admin_users_path %>
+</nav>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Admin - <%= Rails.application.class.module_parent_name %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="turbo-cache-control" content="no-cache">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body>
+    <header>
+      <nav>
+        <%= link_to t("admin.nav.dashboard"), admin_root_path %>
+        <%= link_to t("admin.nav.users"), admin_users_path %>
+        <%= link_to t("admin.nav.faultline"), faultline.root_path %>
+        <%= link_to t("admin.nav.back_to_site"), root_path %>
+      </nav>
+    </header>
+
+    <main>
+      <% if flash[:notice] %>
+        <p role="status"><%= flash[:notice] %></p>
+      <% end %>
+
+      <% if flash[:alert] %>
+        <p role="alert"><%= flash[:alert] %></p>
+      <% end %>
+
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,3 +298,66 @@ en:
       short: "%d %b %H:%M"
     pm: pm
   warrantied: Warrantied
+  admin:
+    title: "Admin"
+    nav:
+      dashboard: "Dashboard"
+      users: "Users"
+      faultline: "Faultline"
+      back_to_site: "Back to Site"
+    dashboard:
+      index:
+        title: "Dashboard"
+        summary: "Summary"
+        total_users: "Total Users"
+        admin_users: "Administrators"
+        recent_signups: "Recent Signups"
+        name: "Name"
+        email: "Email"
+        role: "Role"
+        created_at: "Created"
+        actions: "Actions"
+        view: "View"
+        edit: "Edit"
+    users:
+      index:
+        title: "User Management"
+        new_user: "New User"
+        name: "Name"
+        email: "Email"
+        role: "Role"
+        created_at: "Created"
+        actions: "Actions"
+        view: "View"
+        edit: "Edit"
+        delete: "Delete"
+        confirm_delete: "Are you sure you want to delete this user?"
+      show:
+        title: "User Details"
+        name: "Name"
+        email: "Email"
+        role: "Role"
+        created_at: "Created"
+        active_sessions: "Active Sessions"
+        edit: "Edit"
+        back: "Back"
+      new:
+        title: "New User"
+        submit: "Create User"
+      form:
+        name: "Name"
+        email: "Email"
+        role: "Role"
+        password: "Password"
+        password_confirmation: "Confirm Password"
+        cancel: "Cancel"
+      create:
+        success: "User created successfully"
+      edit:
+        title: "Edit User"
+        submit: "Update User"
+      update:
+        success: "User updated successfully"
+      destroy:
+        success: "User deleted successfully"
+        cannot_delete_self: "You cannot delete yourself"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -300,3 +300,66 @@ nl:
       short: "%d %b %H:%M"
     pm: "'s middags"
   warrantied: Warrantied
+  admin:
+    title: "Admin"
+    nav:
+      dashboard: "Dashboard"
+      users: "Gebruikers"
+      faultline: "Faultline"
+      back_to_site: "Terug naar site"
+    dashboard:
+      index:
+        title: "Dashboard"
+        summary: "Overzicht"
+        total_users: "Totaal gebruikers"
+        admin_users: "Beheerders"
+        recent_signups: "Recente registraties"
+        name: "Naam"
+        email: "E-mail"
+        role: "Rol"
+        created_at: "Aangemaakt"
+        actions: "Acties"
+        view: "Bekijken"
+        edit: "Bewerken"
+    users:
+      index:
+        title: "Gebruikersbeheer"
+        new_user: "Nieuwe gebruiker"
+        name: "Naam"
+        email: "E-mail"
+        role: "Rol"
+        created_at: "Aangemaakt"
+        actions: "Acties"
+        view: "Bekijken"
+        edit: "Bewerken"
+        delete: "Verwijderen"
+        confirm_delete: "Weet je zeker dat je deze gebruiker wilt verwijderen?"
+      show:
+        title: "Gebruikersdetails"
+        name: "Naam"
+        email: "E-mail"
+        role: "Rol"
+        created_at: "Aangemaakt"
+        active_sessions: "Actieve sessies"
+        edit: "Bewerken"
+        back: "Terug"
+      new:
+        title: "Nieuwe gebruiker"
+        submit: "Gebruiker aanmaken"
+      form:
+        name: "Naam"
+        email: "E-mail"
+        role: "Rol"
+        password: "Wachtwoord"
+        password_confirmation: "Wachtwoord bevestigen"
+        cancel: "Annuleren"
+      create:
+        success: "Gebruiker succesvol aangemaakt"
+      edit:
+        title: "Gebruiker bewerken"
+        submit: "Gebruiker bijwerken"
+      update:
+        success: "Gebruiker succesvol bijgewerkt"
+      destroy:
+        success: "Gebruiker succesvol verwijderd"
+        cannot_delete_self: "Je kunt jezelf niet verwijderen"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
   mount Faultline::Engine, at: "/faultline"
+
+  namespace :admin do
+    root "dashboard#index"
+    resources :users
+  end
+
   resources :chattels
   root "dashboard#index"
 
@@ -17,14 +23,14 @@ Rails.application.routes.draw do
 
   resources :transactions
   namespace :transactions do
-    resources :imports, only: [:create]
+    resources :imports, only: [ :create ]
   end
   resources :credit, controller: "transactions", type: "Transaction"
   resources :debit, controller: "transactions", type: "Transaction"
   resources :transfer, controller: "transactions", type: "Transaction"
   resources :accounts do
     scope module: "accounts" do
-      resource :transactions_bulk, only: [:update]
+      resource :transactions_bulk, only: [ :update ]
     end
   end
   resources :categories

--- a/test/integration/admin/dashboard_test.rb
+++ b/test/integration/admin/dashboard_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Admin::DashboardTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:admin)
+    @member = users(:member)
+  end
+
+  test "non-admin user is redirected away" do
+    sign_in_as(@member)
+    get admin_root_path
+
+    assert_redirected_to root_path
+  end
+
+  test "admin can access dashboard and sees user table" do
+    sign_in_as(@admin)
+    get admin_root_path
+
+    assert_response :success
+    assert_select "table"
+    assert_select "td", text: @admin.email_address
+  end
+
+  test "dashboard shows user counts" do
+    sign_in_as(@admin)
+    get admin_root_path
+
+    assert_response :success
+    assert_select "dd", text: User.count.to_s
+    assert_select "dd", text: User.administrator.count.to_s
+  end
+end

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class Admin::UsersTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:admin)
+    @member = users(:member)
+  end
+
+  test "admin can list users" do
+    sign_in_as(@admin)
+    get admin_users_path
+
+    assert_response :success
+    assert_select "td", text: @member.email_address
+  end
+
+  test "admin can view a user" do
+    sign_in_as(@admin)
+    get admin_user_path(@member)
+
+    assert_response :success
+    assert_select "dd", text: @member.email_address
+  end
+
+  test "admin can reach new user form" do
+    sign_in_as(@admin)
+    get new_admin_user_path
+
+    assert_response :success
+    assert_select "form"
+  end
+
+  test "admin can edit a user" do
+    sign_in_as(@admin)
+    get edit_admin_user_path(@member)
+
+    assert_response :success
+    assert_select "form"
+  end
+
+  test "admin can update a user role" do
+    sign_in_as(@admin)
+    patch admin_user_path(@member), params: { user: { role: "administrator" } }
+
+    assert_redirected_to admin_user_path(@member)
+    assert_equal "administrator", @member.reload.role
+  end
+
+  test "admin cannot delete themselves" do
+    sign_in_as(@admin)
+
+    assert_no_difference("User.count") do
+      delete admin_user_path(@admin)
+    end
+
+    assert_redirected_to admin_users_path
+  end
+
+  test "non-admin user is redirected for all actions" do
+    sign_in_as(@member)
+
+    get admin_users_path
+    assert_redirected_to root_path
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,3 +11,9 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
 end
+
+class ActionDispatch::IntegrationTest
+  def sign_in_as(user)
+    post session_url, params: { email_address: user.email_address, password: "password123" }
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Admin::DashboardController` with user counts (total, administrators) and recent signups table
- Adds `Admin::UsersController` with full CRUD (index, show, new, create, edit, update, destroy)
- Adds admin layout, views, and i18n keys (en + nl)
- Adapted for this app: uses `email_address`, `administrator?`/`User.administrator` instead of `admin?`
- Adds integration tests for dashboard and users

## Test plan
- [ ] Sign in as an administrator and visit `/admin`
- [ ] Verify dashboard shows correct user counts and recent signups table
- [ ] Visit `/admin/users` and verify all users are listed
- [ ] Create a new user via `/admin/users/new`
- [ ] Edit an existing user's role
- [ ] Verify non-admin users are redirected to root
- [ ] Verify admin cannot delete themselves
- [ ] Run `bin/rails test test/integration/admin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)