### PR TITLE
Fix: Resolve Faultline dashboard authorization for admin users

### DIFF
--- a/config/initializers/faultline.rb
+++ b/config/initializers/faultline.rb
@@ -44,11 +44,10 @@ Faultline.configure do |config|
   # Return true if the user should have access to the dashboard
   # IMPORTANT: Configure this before deploying to production!
   config.authenticate_with = lambda do |request|
-    raw = request.cookies[:session_token]
-    next false unless raw
-    token = Rails.application.message_verifier("signed cookie").verify(raw)
+    token = request.cookie_jar.signed[:session_token]
+    next false unless token
     Session.find_by(token: token)&.user&.can_administer?
-  rescue ActiveSupport::MessageVerifier::InvalidSignature
+  rescue => e
     false
   end
 


### PR DESCRIPTION
## Summary

Rails 8.0's default `use_cookies_with_metadata` feature signs cookies with embedded purpose metadata. The Faultline dashboard's authentication lambda was manually decoding signed cookies without accounting for this, causing verification failures and returning "unauthorized" even for admin users.

## Changes

Updated `config/initializers/faultline.rb` to use `request.cookie_jar.signed[:session_token]` instead of manually calling `Rails.application.message_verifier("signed cookie").verify(raw)`. This uses Rails' built-in signed cookie mechanism that properly handles metadata and purpose verification.

## Test Plan

- [ ] Log in as an administrator and navigate to `/faultline` — should display the error dashboard
- [ ] Log in as a non-administrator user and navigate to `/faultline` — should show unauthorized error

🤖 Generated with Claude Code