### PR TITLE
Clean up resource show pages and add integration coverage

### DIFF
--- a/app/views/accounts/_form.html.haml
+++ b/app/views/accounts/_form.html.haml
@@ -6,6 +6,9 @@
         - @account.errors.full_messages.each do |message|
           %li= message
 
+  .actions
+    = f.submit t('common.save')
+
   .field
     = f.label :id
     = f.text_field :id, disabled: :disabled
@@ -21,5 +24,3 @@
   .field
     = f.label :category_id
     = f.collection_select :category_id, Category.all.order(:name), :id, :name, { include_blank: true }
-  .actions
-    = f.submit t('common.save')

--- a/app/views/accounts/edit.html.haml
+++ b/app/views/accounts/edit.html.haml
@@ -1,5 +1,6 @@
-%h1
-  = @account.name
-  = link_to @account do
-    %b= t('common.show')
+%header
+  %h1= @account.name
+  %nav
+    = link_to @account do
+      %b= t('common.show')
 = render 'form'

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,9 +1,11 @@
-<h1>
-  <%= @account.name %>
-  <%= link_to edit_account_path(@account) do %>
-    <b><%= t('.edit') %></b>
-  <% end %>
-</h1>
+<header>
+  <h1><%= @account.name %></h1>
+  <nav>
+    <%= link_to edit_account_path(@account) do %>
+      <b><%= t('.edit') %></b>
+    <% end %>
+  </nav>
+</header>
 
 <p>
   <b><%= t('.id') %></b>

--- a/app/views/categories/_form.html.haml
+++ b/app/views/categories/_form.html.haml
@@ -8,6 +8,10 @@
           - @category.errors.full_messages.each do |message|
             %li= message
 
+    - unless disabled
+      .actions
+        = f.submit t('common.save')
+
     = f.label :name
     = f.text_field :name, disabled: disabled
 
@@ -16,7 +20,3 @@
 
     = f.label :parent_category
     = f.grouped_collection_select :parent_category_id, Category.groups, :children, :name, :id, :name, { include_blank: true }
-
-    - unless disabled
-      .actions
-        = f.submit t('common.save')

--- a/app/views/categories/edit.html.haml
+++ b/app/views/categories/edit.html.haml
@@ -1,8 +1,8 @@
-%h1
-  = @category.name
-  = link_to @category do
-    %b= t('common.show')
-  = link_to @category, data: { turbo_method: :delete, turbo_confirm: t('common.confirm_destroy') } do
-    %b= t('common.destroy')
+%header
+  %h1= @category.name
+  %nav
+    = link_to @category do
+      %b= t('common.show')
+    = button_to t('common.destroy'), @category, method: :delete, data: { turbo_confirm: t('common.confirm_destroy') }
 
 = render 'form'

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,6 +1,7 @@
-%h1
-  = @category.name
-  = link_to edit_category_path(@category) do
-    %b= t('common.edit')
+%header
+  %h1= @category.name
+  %nav
+    = link_to edit_category_path(@category) do
+      %b= t('common.edit')
 
 = render partial: 'form', locals: { disabled: :disabled }

--- a/app/views/chattels/_form.html.haml
+++ b/app/views/chattels/_form.html.haml
@@ -1,40 +1,44 @@
-= form_for @chattel do |f|
-  - if @chattel.errors.any?
-    #error_explanation
-      %h2= t('errors.template.header', count: @chattel.errors.count, model: Chattel.model_name.human.downcase)
-      %ul
-        - @chattel.errors.full_messages.each do |message|
-          %li= message
+- disabled ||= nil
+%section
+  = form_for @chattel do |f|
+    - if @chattel.errors.any?
+      #error_explanation
+        %h2= t('errors.template.header', count: @chattel.errors.count, model: Chattel.model_name.human.downcase)
+        %ul
+          - @chattel.errors.full_messages.each do |message|
+            %li= message
 
-  .field
-    = f.label :name
-    = f.text_field :name
-  .field
-    = f.label :kind
-    = f.text_field :kind
-  .field
-    = f.label :model_number
-    = f.text_field :model_number
-  .field
-    = f.label :serial_number
-    = f.text_field :serial_number
-  .field
-    = f.label :purchase_transaction_id
-    = f.number_field :purchase_transaction_id
-  .field
-    = f.label :purchased_at
-    = f.date_field :purchased_at
-  .field
-    = f.label :warranty_expires_at
-    = f.date_field :warranty_expires_at
-  .field
-    = f.label :left_possession_at
-    = f.date_field :left_possession_at
-  .field
-    = f.label :purchase_price
-    = f.text_field :purchase_price
-  .field
-    = f.label :notes
-    = f.text_area :notes
-  .actions
-    = f.submit t('common.save')
+    - unless disabled
+      .actions
+        = f.submit t('common.save')
+
+    .field
+      = f.label :name
+      = f.text_field :name, disabled: disabled
+    .field
+      = f.label :kind
+      = f.text_field :kind, disabled: disabled
+    .field
+      = f.label :model_number
+      = f.text_field :model_number, disabled: disabled
+    .field
+      = f.label :serial_number
+      = f.text_field :serial_number, disabled: disabled
+    .field
+      = f.label :purchase_transaction_id
+      = f.number_field :purchase_transaction_id, disabled: disabled
+    .field
+      = f.label :purchased_at
+      = f.date_field :purchased_at, disabled: disabled
+    .field
+      = f.label :warranty_expires_at
+      = f.date_field :warranty_expires_at, disabled: disabled
+    .field
+      = f.label :left_possession_at
+      = f.date_field :left_possession_at, disabled: disabled
+    .field
+      = f.label :purchase_price
+      = f.text_field :purchase_price, disabled: disabled
+    .field
+      = f.label :notes
+      = f.text_area :notes, disabled: disabled

--- a/app/views/chattels/edit.html.haml
+++ b/app/views/chattels/edit.html.haml
@@ -1,7 +1,8 @@
-%h1= t('.title')
+%header
+  %h1= @chattel.name
+  %nav
+    = link_to @chattel do
+      %b= t('common.show')
+    = button_to t('common.destroy'), @chattel, method: :delete, data: { turbo_confirm: t('common.confirm_destroy') }
 
 = render 'form'
-
-= link_to t('common.show'), @chattel
-\|
-= link_to t('common.back'), chattels_path

--- a/app/views/chattels/show.html.haml
+++ b/app/views/chattels/show.html.haml
@@ -1,36 +1,7 @@
-%p#notice= notice
+%header
+  %h1= @chattel.name
+  %nav
+    = link_to edit_chattel_path(@chattel) do
+      %b= t('common.edit')
 
-%p
-  %b= "#{Chattel.human_attribute_name(:name)}:"
-  = @chattel.name
-%p
-  %b= "#{Chattel.human_attribute_name(:kind)}:"
-  = @chattel.kind
-%p
-  %b= "#{Chattel.human_attribute_name(:model_number)}:"
-  = @chattel.model_number
-%p
-  %b= "#{Chattel.human_attribute_name(:serial_number)}:"
-  = @chattel.serial_number
-%p
-  %b= "#{Chattel.human_attribute_name(:purchase_transaction)}:"
-  = @chattel.purchase_transaction
-%p
-  %b= "#{Chattel.human_attribute_name(:purchased_at)}:"
-  = l(@chattel.purchased_at, format: :short) if @chattel.purchased_at.present?
-%p
-  %b= "#{Chattel.human_attribute_name(:warranty_expires_at)}:"
-  = l(@chattel.warranty_expires_at, format: :short) if @chattel.warranty_expires_at.present?
-%p
-  %b= "#{Chattel.human_attribute_name(:left_possession_at)}:"
-  = l @chattel.left_possession_at, format: :short if @chattel.left_possession_at
-%p
-  %b= "#{Chattel.human_attribute_name(:purchase_price)}:"
-  = @chattel.purchase_price
-%p
-  %b= "#{Chattel.human_attribute_name(:notes)}:"
-  = @chattel.notes
-
-= link_to t('common.edit'), edit_chattel_path(@chattel)
-\|
-= link_to t('common.back'), chattels_path
+= render partial: 'form', locals: { disabled: :disabled }

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -14,6 +14,12 @@
       </div>
     <% end %>
 
+    <% unless disabled %>
+      <div class="actions">
+        <%= f.submit t('common.save') %>
+      </div>
+    <% end %>
+
     <%= f.label :id %>
     <%= f.text_field :id, disabled: :disabled %>
 
@@ -56,10 +62,5 @@
       <%= f.text_field :original_tag, disabled: true %>
     <% end %>
 
-    <% unless disabled %>
-      <div class="actions">
-        <%= f.submit t('common.save') %>
-      </div>
-    <% end %>
   <% end %>
 </section>

--- a/app/views/transactions/edit.html.haml
+++ b/app/views/transactions/edit.html.haml
@@ -3,13 +3,11 @@
     %ul
       %li= link_to t('transactions.index.all_transactions'), transactions_path
       %li= link_to t('transactions.index.consolidatable'), transactions_path(filter: :no_category)
-%h1
-  = "#{@transaction.creditor} ➡️ #{@transaction.debitor}"
-  = link_to @transaction do
-    %b= t('common.show')
+%header
+  %h1= "#{@transaction.creditor} ➡️ #{@transaction.debitor}"
+  %nav
+    = link_to @transaction do
+      %b= t('common.show')
+    = button_to t('common.destroy'), @transaction, method: :delete, data: { turbo_confirm: t('common.confirm_destroy') }
 
 = render partial: 'form'
-
-%section
-  = link_to @transaction, data: { turbo_method: :delete, turbo_confirm: t('common.confirm_destroy') } do
-    %b= t('common.destroy')

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -7,11 +7,52 @@
   </nav>
 <% end %>
 
-<h1>
-  <%= "#{@transaction.creditor} ➡️ #{@transaction.debitor}" %>
-  <%= link_to edit_transaction_path(@transaction) do %>
-    <b><%= t('common.edit') %></b>
-  <% end %>
-</h1>
+<header>
+  <h1><%= "#{@transaction.creditor} ➡️ #{@transaction.debitor}" %></h1>
+  <nav>
+    <%= link_to edit_transaction_path(@transaction) do %>
+      <b><%= t('common.edit') %></b>
+    <% end %>
+  </nav>
+</header>
 
-<%= render partial: 'form', locals: { disabled: :disabled } %>
+<dl>
+  <dt><%= t('transactions.table.type') %></dt>
+  <dd><%= @transaction.type_icon %> <%= @transaction.type %></dd>
+
+  <dt><%= t('transactions.table.creditor') %></dt>
+  <% creditor = @transaction.creditor %>
+  <dd><%= creditor ? link_to(creditor.to_s, account_path(creditor)) : '-' %></dd>
+
+  <dt><%= t('transactions.table.debitor') %></dt>
+  <% debitor = @transaction.debitor %>
+  <dd><%= debitor ? link_to(debitor.to_s, account_path(debitor)) : '-' %></dd>
+
+  <dt><%= t('transactions.table.amount') %></dt>
+  <dd><%= number_to_currency(@transaction.amount) %></dd>
+
+  <dt><%= t('transactions.table.category') %></dt>
+  <dd><%= @transaction.category&.name || '-' %></dd>
+
+  <dt><%= t('transactions.table.booked_at') %></dt>
+  <dd><%= @transaction.booked_at ? l(@transaction.booked_at.to_date) : '-' %></dd>
+
+  <dt><%= t('transactions.table.interest_date') %></dt>
+  <dd><%= @transaction.interest_at ? l(@transaction.interest_at.to_date) : '-' %></dd>
+
+  <dt><%= t('transactions.table.note') %></dt>
+  <dd><%= @transaction.note %></dd>
+</dl>
+
+<% if Current.user.can_administer? %>
+  <dl>
+    <dt><%= Transaction.human_attribute_name(:original_note) %></dt>
+    <dd><%= @transaction.original_note %></dd>
+
+    <dt><%= Transaction.human_attribute_name(:original_balance_after_mutation) %></dt>
+    <dd><%= @transaction.original_balance_after_mutation %></dd>
+
+    <dt><%= Transaction.human_attribute_name(:original_tag) %></dt>
+    <dd><%= @transaction.original_tag %></dd>
+  </dl>
+<% end %>

--- a/test/integration/chattels_show_test.rb
+++ b/test/integration/chattels_show_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class ChattelsShowTest < ActionDispatch::IntegrationTest
+  setup do
+    @chattel = chattels(:one)
+    @member = users(:member)
+  end
+
+  test "show renders read-only form without save action" do
+    sign_in_as(@member)
+
+    get chattel_url(@chattel)
+
+    assert_response :success
+    assert_select "form"
+    assert_select "input[type=submit][value='Save']", count: 0
+    assert_select "input[name='chattel[name]'][disabled]"
+    assert_select "textarea[name='chattel[notes]'][disabled]"
+  end
+
+  test "show includes navigation to edit page" do
+    sign_in_as(@member)
+
+    get chattel_url(@chattel)
+
+    assert_response :success
+    assert_select "a[href='#{edit_chattel_path(@chattel)}']", text: I18n.t("common.edit")
+  end
+end

--- a/test/integration/transactions_show_test.rb
+++ b/test/integration/transactions_show_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class TransactionsShowTest < ActionDispatch::IntegrationTest
+  setup do
+    @transaction = transactions(:debit_grocery)
+    @uncategorized = transactions(:uncategorized)
+    @admin = users(:admin)
+    @member = users(:member)
+  end
+
+  test "show renders uncategorized category as dash" do
+    sign_in_as(@member)
+
+    get transaction_url(@uncategorized)
+
+    assert_response :success
+    assert_select "dt", text: I18n.t("transactions.table.category")
+    assert_select "dd", text: "-"
+  end
+
+  test "show renders original import fields for administrators" do
+    @transaction.update!(
+      original_note: "Imported original note",
+      original_balance_after_mutation: "1200.50",
+      original_tag: "ORIG-TAG"
+    )
+
+    sign_in_as(@admin)
+
+    get transaction_url(@transaction)
+
+    assert_response :success
+    assert_select "dd", text: "Imported original note"
+    assert_select "dd", text: /1200\.5/
+    assert_select "dd", text: "ORIG-TAG"
+  end
+
+  test "show hides original import fields for non-admin users" do
+    @transaction.update!(
+      original_note: "Imported original note",
+      original_balance_after_mutation: "1200.50",
+      original_tag: "ORIG-TAG"
+    )
+
+    sign_in_as(@member)
+
+    get transaction_url(@transaction)
+
+    assert_response :success
+    assert_select "dd", text: "Imported original note", count: 0
+    assert_select "dd", text: /1200\.5/, count: 0
+    assert_select "dd", text: "ORIG-TAG", count: 0
+  end
+end


### PR DESCRIPTION
This PR refactors account, category, chattel, and transaction edit/show views to use consistent header/navigation structure and improved form action placement. It replaces link_to method-delete usages in edited views with button_to and turbo_confirm for Turbo-compatible destructive actions. The transaction show page is now a read-only details layout with explicit field rendering, admin-only original import fields, and a consistent dash fallback for uncategorized transactions. It also adds integration tests for chattel and transaction show pages to cover read-only rendering, navigation, and admin visibility behavior.