### PR TITLE
Split accounts index into own and external tables

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -17,6 +17,10 @@ words:
   - FactoryBot
   - Rubygems
   - Gemfile
+  - Recordset
+  - Pagy
+  - NLOWN
+  - NLEXT
 ignorePaths:
   - app/assets
   - bin/**

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -6,9 +6,9 @@ class AccountsController < ApplicationController
   #
   # @return [void]
   def index
-    @own_page      = GearedPagination::Recordset.new(Account.own,      per_page: [ 50 ]).page(params[:own_page])
-    @own_accounts  = @own_page.records
-    @external_page     = GearedPagination::Recordset.new(Account.external, per_page: [ 50 ]).page(params[:external_page])
+    @own_page = GearedPagination::Recordset.new(Account.own.order(:id), per_page: [ 50 ]).page(params[:own_page])
+    @own_accounts = @own_page.records
+    @external_page = GearedPagination::Recordset.new(Account.external.order(:id), per_page: [ 50 ]).page(params[:external_page])
     @external_accounts = @external_page.records
   end
 

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,4 +1,4 @@
-<section>
+<section id="own-accounts">
   <h2><%= t('.own_accounts') %></h2>
 
   <% if @own_page.number > 1 || @own_page.before_last? %>
@@ -12,7 +12,7 @@
     </nav>
   <% end %>
 
-  <table class="accounts">
+  <table class="accounts" id="own-accounts-table">
     <thead>
       <tr>
         <th></th>
@@ -60,7 +60,7 @@
   <% end %>
 </section>
 
-<section>
+<section id="external-accounts">
   <h2><%= t('.external_accounts') %></h2>
 
   <% if @external_page.number > 1 || @external_page.before_last? %>
@@ -74,7 +74,7 @@
     </nav>
   <% end %>
 
-  <table class="accounts">
+  <table class="accounts" id="external-accounts-table">
     <thead>
       <tr>
         <th></th>

--- a/test/integration/accounts_index_test.rb
+++ b/test/integration/accounts_index_test.rb
@@ -13,13 +13,13 @@ class AccountsIndexTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: I18n.t("accounts.index.own_accounts")
     assert_select "h2", text: I18n.t("accounts.index.external_accounts")
 
-    assert_select "section:nth-of-type(1) table.accounts tbody td", text: accounts(:checking).name
-    assert_select "section:nth-of-type(1) table.accounts tbody td", text: accounts(:savings).name
-    assert_select "section:nth-of-type(2) table.accounts tbody td", text: accounts(:albert_heijn).name
-    assert_select "section:nth-of-type(2) table.accounts tbody td", text: accounts(:employer).name
+    assert_select "#own-accounts-table tbody td", text: accounts(:checking).name
+    assert_select "#own-accounts-table tbody td", text: accounts(:savings).name
+    assert_select "#external-accounts-table tbody td", text: accounts(:albert_heijn).name
+    assert_select "#external-accounts-table tbody td", text: accounts(:employer).name
 
-    assert_select "section:nth-of-type(1) table.accounts thead th", text: I18n.t("accounts.index.owner")
-    assert_select "section:nth-of-type(2) table.accounts thead th", text: I18n.t("accounts.index.owner"), count: 0
+    assert_select "#own-accounts-table thead th", text: I18n.t("accounts.index.owner")
+    assert_select "#external-accounts-table thead th", text: I18n.t("accounts.index.owner"), count: 0
   end
 
   test "own and external pagination params are independent" do
@@ -39,13 +39,13 @@ class AccountsIndexTest < ActionDispatch::IntegrationTest
     get accounts_path, params: { own_page: 1, external_page: 1 }
     assert_response :success
 
-    own_items_per_page = css_select("section:nth-of-type(1) table.accounts tbody tr").size
-    external_items_per_page = css_select("section:nth-of-type(2) table.accounts tbody tr").size
+    own_items_per_page = css_select("#own-accounts-table tbody tr").size
+    external_items_per_page = css_select("#external-accounts-table tbody tr").size
 
-    own_page_1_number = Account.own.limit(1).pick(:account_number)
-    own_page_2_number = Account.own.offset(own_items_per_page).limit(1).pick(:account_number)
-    external_page_1_number = Account.external.limit(1).pick(:account_number)
-    external_page_2_number = Account.external.offset(external_items_per_page).limit(1).pick(:account_number)
+    own_page_1_number = Account.own.order(:id).limit(1).pick(:account_number)
+    own_page_2_number = Account.own.order(:id).offset(own_items_per_page).limit(1).pick(:account_number)
+    external_page_1_number = Account.external.order(:id).limit(1).pick(:account_number)
+    external_page_2_number = Account.external.order(:id).offset(external_items_per_page).limit(1).pick(:account_number)
 
     get accounts_path, params: { own_page: 2, external_page: 1 }
 


### PR DESCRIPTION
## Summary

Add named scopes (own/external) to Account model and split the accounts index view into two separate, independently paginated tables: one for family accounts (with owner set) and one for external accounts (owner nil). The external table omits the owner column since it's always nil.

## Changes

- Add `:own` and `:external` scopes to Account model
- Replace single `pagy Account.all` with two independent queries using `page_param: :own_page` / `:external_page`
- Update view with two sections, each with an h2 heading, its own pagination, and its own table
- Add i18n keys `own_accounts` / `external_accounts` under `accounts.index` in all locales (en/nl/it)
- Add scope tests to account_test.rb using existing fixtures

## Test Plan

- [x] All 10 account model tests pass (including 2 new scope tests)
- [ ] Visit `/accounts` to verify two tables render with correct rows
- [ ] Paginate each table independently and verify page parameters stay separate
- [ ] Verify the external table omits the owner column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
