### PR TITLE
Add profile tab and admin link to main navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,10 @@
           <li><%= link_to t('main_nav.categories', model: Category.model_name.human), categories_path %></li>
           <li><%= link_to t('main_nav.chattels', model: Chattel.model_name.human), chattels_path %></li>
           <li><%= link_to t('main_nav.todo', model: Todo.model_name.human), todo_path %></li>
+          <li><%= link_to t('main_nav.profile'), edit_user_profile_path(Current.user) %></li>
+          <% if Current.user.can_administer? %>
+            <li><%= link_to t('main_nav.admin'), admin_root_path %></li>
+          <% end %>
         </ul>
       </nav>
     </header>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,6 +324,8 @@ en:
     dashboard_filters: "🔎 Filters"
     journal_views: "📚 Views"
     todo: "✅ %{model}"
+    profile: "👤 Profile"
+    admin: "🥷 Admin"
   number:
     currency:
       format:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -324,6 +324,8 @@ it:
     dashboard_filters: "🔎 Filtri"
     journal_views: "📚 Viste"
     todo: "✅ %{model}"
+    profile: "👤 Profilo"
+    admin: "🥷 Amministrazione"
   number:
     currency:
       format:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -324,6 +324,8 @@ nl:
     dashboard_filters: "🔎 Filters"
     journal_views: "📚 Weergaven"
     todo: "✅ %{model}"
+    profile: "👤 Profiel"
+    admin: "🥷 Beheer"
   number:
     currency:
       format:


### PR DESCRIPTION
## Summary
- Adds a Profile nav link for all users pointing to their settings/edit page
- Adds a conditional Admin nav link visible only to users with `can_administer?` privilege
- Adds translations for `main_nav.profile` and `main_nav.admin` in English, Dutch, and Italian locales