### PR TITLE
Use grouped category selector on Accounts#edit

### DIFF
--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -32,6 +32,6 @@
   </div>
   <div class="field">
     <%= f.label :category_id %>
-    <%= f.collection_select :category_id, Category.all.order(:name), :id, :name, { include_blank: true } %>
+    <%= f.select :category_id, grouped_category_options(selected: f.object.category_id), { include_blank: true } %>
   </div>
 <% end %>


### PR DESCRIPTION
## Summary

- Replace the flat `collection_select` for `category_id` on the accounts form with the `grouped_category_options` helper, matching the grouped category dropdown already used on the transactions form.

## Test plan

- [ ] Visit `/accounts/:id/edit` and verify the category dropdown shows categories grouped by parent
- [ ] Verify selected category is pre-selected when editing an existing account

🤖 Generated with [Claude Code](https://claude.com/claude-code)