### PR TITLE
Add recent transaction panels for accounts and categories

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -21,6 +21,18 @@ class Account < ApplicationRecord
 
   validates :account_number, uniqueness: true, allow_blank: true
 
+  # Returns the 10 most recent transactions involving this account as debitor or creditor
+  #
+  # @param limit [Integer] Maximum number of transactions to return
+  # @return [ActiveRecord::Relation] Transactions ordered by most recent first
+  def recent_transactions(limit: 10)
+    Transaction
+      .includes(:creditor, :debitor, :category)
+      .where("debitor_account_id = :id OR creditor_account_id = :id", id: id)
+      .order(booked_at: :desc, id: :desc)
+      .limit(limit)
+  end
+
   # Returns human-readable string representation of the account
   #
   # @return [String] Account name if present, otherwise account number

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -20,6 +20,18 @@ class Category < ApplicationRecord
 
   validates :direction, presence: true
 
+  # Returns the most recent transactions for this category and its children
+  #
+  # @param limit [Integer] Maximum number of transactions to return
+  # @return [ActiveRecord::Relation] Transactions ordered by most recent first
+  def recent_transactions(limit: 10)
+    Transaction
+      .where(category_id: children.select(:id))
+      .includes(:creditor, :debitor, :category)
+      .order(booked_at: :desc, id: :desc)
+      .limit(limit)
+  end
+
   # Returns all children of this category plus itself
   #
   # @return [ActiveRecord::Relation] Self and all child categories

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -9,3 +9,7 @@
 <article>
   <%= render 'form' %>
 </article>
+
+<article>
+  <%= render "shared/recent_transactions", transactions: @account.recent_transactions %>
+</article>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -31,3 +31,7 @@
 
 <%= button_to t('.update_transactions'), account_transactions_bulk_path(@account), method: :patch %>
 </article>
+
+<article>
+  <%= render "shared/recent_transactions", transactions: @account.recent_transactions %>
+</article>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -10,3 +10,7 @@
 <article>
   <%= render 'form' %>
 </article>
+
+<article>
+  <%= render "shared/recent_transactions", transactions: @category.recent_transactions %>
+</article>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -9,3 +9,7 @@
 <article>
   <%= render partial: 'form', locals: { disabled: :disabled } %>
 </article>
+
+<article>
+  <%= render "shared/recent_transactions", transactions: @category.recent_transactions %>
+</article>

--- a/app/views/shared/_recent_transactions.html.erb
+++ b/app/views/shared/_recent_transactions.html.erb
@@ -1,0 +1,32 @@
+<%# locals: (transactions:) %>
+<h2><%= t("transactions.recent.heading") %></h2>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= t("transactions.table.type") %></th>
+      <th><%= t("transactions.table.creditor") %></th>
+      <th><%= t("transactions.table.debitor") %></th>
+      <th><%= t("transactions.table.amount") %></th>
+      <th><%= t("transactions.table.booked_at") %></th>
+      <th><%= t("transactions.table.category") %></th>
+      <th><%= t("transactions.table.note") %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% transactions.each do |transaction| %>
+      <tr>
+        <td><%= transaction.type_icon %></td>
+        <% creditor = transaction.creditor %>
+        <td><%= creditor ? link_to(creditor.name || creditor.account_number, account_path(creditor)) : "" %></td>
+        <% debitor = transaction.debitor %>
+        <td><%= debitor ? link_to(debitor.name || debitor.account_number, account_path(debitor)) : "" %></td>
+        <td><%= number_to_currency transaction.amount %></td>
+        <td><%= transaction.booked_at ? l(transaction.booked_at.to_date) : "" %></td>
+        <td><%= transaction.category&.to_s %></td>
+        <td><%= transaction.note&.truncate(20) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,6 +452,8 @@ en:
       upload: Upload
     new:
       title: "➕ New transaction"
+    recent:
+      heading: Recent transactions
     table:
       amount: Amount
       booked_at: Booked at date

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -452,6 +452,8 @@ it:
       upload: Carica
     new:
       title: "➕ Nuova transazione"
+    recent:
+      heading: Transazioni recenti
     table:
       amount: Importo
       booked_at: Data registrazione

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -452,6 +452,8 @@ nl:
       upload: Uploaden
     new:
       title: "➕ Nieuwe transactie"
+    recent:
+      heading: Recente transacties
     table:
       amount: Bedrag
       booked_at: Boekingsdatum

--- a/test/integration/accounts_show_test.rb
+++ b/test/integration/accounts_show_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class AccountsShowTest < ActionDispatch::IntegrationTest
+  setup do
+    @member = users(:member)
+    sign_in_as(@member)
+  end
+
+  test "show renders recent transactions heading" do
+    get account_path(accounts(:checking))
+
+    assert_response :success
+    assert_select "h2", text: I18n.t("transactions.recent.heading")
+  end
+
+  test "show renders a transaction where account is debitor" do
+    get account_path(accounts(:checking))
+
+    assert_response :success
+    assert_includes response.body, transactions(:debit_grocery).note
+  end
+
+  test "edit renders recent transactions heading" do
+    get edit_account_path(accounts(:checking))
+
+    assert_response :success
+    assert_select "h2", text: I18n.t("transactions.recent.heading")
+  end
+
+  test "edit renders a transaction where account is creditor" do
+    get edit_account_path(accounts(:checking))
+
+    assert_response :success
+    assert_includes response.body, transactions(:credit_salary).note
+  end
+end

--- a/test/integration/categories_show_test.rb
+++ b/test/integration/categories_show_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class CategoriesShowTest < ActionDispatch::IntegrationTest
+  setup do
+    @member = users(:member)
+    sign_in_as(@member)
+  end
+
+  test "show renders recent transactions heading" do
+    get category_path(categories(:supermarket))
+
+    assert_response :success
+    assert_select "h2", text: I18n.t("transactions.recent.heading")
+  end
+
+  test "show renders transactions for the category" do
+    get category_path(categories(:supermarket))
+
+    assert_response :success
+    assert_includes response.body, transactions(:debit_grocery).note
+  end
+
+  test "show for parent category renders transactions from child categories" do
+    get category_path(categories(:groceries))
+
+    assert_response :success
+    assert_includes response.body, transactions(:debit_grocery).note
+    assert_includes response.body, transactions(:debit_bakery).note
+  end
+
+  test "edit renders recent transactions heading" do
+    get edit_category_path(categories(:supermarket))
+
+    assert_response :success
+    assert_select "h2", text: I18n.t("transactions.recent.heading")
+  end
+
+  test "edit renders transactions for the category" do
+    get edit_category_path(categories(:supermarket))
+
+    assert_response :success
+    assert_includes response.body, transactions(:debit_grocery).note
+  end
+
+  test "edit for parent category renders transactions from child categories" do
+    get edit_category_path(categories(:groceries))
+
+    assert_response :success
+    assert_includes response.body, transactions(:debit_grocery).note
+    assert_includes response.body, transactions(:debit_bakery).note
+  end
+end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -57,6 +57,97 @@ class AccountTest < ActiveSupport::TestCase
     assert accounts(:savings).valid?
   end
 
+  # -- recent_transactions ----------------------------------------------------
+
+  test "recent_transactions returns transactions where account is debitor" do
+    result = accounts(:checking).recent_transactions
+
+    assert_includes result, transactions(:debit_grocery)
+  end
+
+  test "recent_transactions returns transactions where account is creditor" do
+    result = accounts(:checking).recent_transactions
+
+    assert_includes result, transactions(:credit_salary)
+  end
+
+  test "recent_transactions respects the limit parameter" do
+    result = accounts(:checking).recent_transactions(limit: 2)
+
+    assert_equal 2, result.count
+  end
+
+  test "recent_transactions defaults to a limit of ten" do
+    11.times do |index|
+      Transaction.create!(
+        amount: 10 + index,
+        booked_at: 20.days.from_now + index.minutes,
+        interest_at: 20.days.from_now + index.minutes,
+        debitor: accounts(:checking),
+        creditor: accounts(:albert_heijn),
+        category: categories(:supermarket)
+      )
+    end
+
+    assert_equal 10, accounts(:checking).recent_transactions.count
+  end
+
+  test "recent_transactions are ordered by booked_at descending" do
+    older = Transaction.create!(
+      amount: 20,
+      booked_at: 30.days.from_now,
+      interest_at: 30.days.from_now,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+    newer = Transaction.create!(
+      amount: 30,
+      booked_at: 31.days.from_now,
+      interest_at: 31.days.from_now,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+
+    result_ids = accounts(:checking).recent_transactions(limit: 2).pluck(:id)
+
+    assert_equal [ newer.id, older.id ], result_ids
+  end
+
+  test "recent_transactions break booked_at ties with newest record first" do
+    timestamp = 60.days.from_now
+
+    first = Transaction.create!(
+      amount: 60,
+      booked_at: timestamp,
+      interest_at: timestamp,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+    second = Transaction.create!(
+      amount: 70,
+      booked_at: timestamp,
+      interest_at: timestamp,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+
+    result_ids = accounts(:checking).recent_transactions(limit: 2).pluck(:id)
+
+    assert_equal [ second.id, first.id ], result_ids
+  end
+
+  test "recent_transactions preloads associations used by the view" do
+    relation = accounts(:checking).recent_transactions
+
+    assert_includes relation.includes_values, :creditor
+    assert_includes relation.includes_values, :debitor
+    assert_includes relation.includes_values, :category
+  end
+
   # -- to_s -------------------------------------------------------------------
 
   test "to_s returns name when present" do

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -60,6 +60,104 @@ class CategoryTest < ActiveSupport::TestCase
     assert_equal "Groceries", categories(:groceries).full_name
   end
 
+  # -- recent_transactions ----------------------------------------------------
+
+  test "recent_transactions returns transactions for the category" do
+    result = categories(:supermarket).recent_transactions
+
+    assert_includes result, transactions(:debit_grocery)
+  end
+
+  test "recent_transactions excludes transactions for other categories" do
+    result = categories(:supermarket).recent_transactions
+
+    assert_not_includes result, transactions(:credit_salary)
+  end
+
+  test "recent_transactions for a parent category includes child category transactions" do
+    result = categories(:groceries).recent_transactions
+
+    assert_includes result, transactions(:debit_grocery)
+    assert_includes result, transactions(:debit_bakery)
+  end
+
+  test "recent_transactions respects the limit parameter" do
+    result = categories(:supermarket).recent_transactions(limit: 0)
+
+    assert_equal 0, result.count
+  end
+
+  test "recent_transactions defaults to a limit of ten" do
+    11.times do |index|
+      Transaction.create!(
+        amount: 10 + index,
+        booked_at: 40.days.from_now + index.minutes,
+        interest_at: 40.days.from_now + index.minutes,
+        debitor: accounts(:checking),
+        creditor: accounts(:albert_heijn),
+        category: categories(:supermarket)
+      )
+    end
+
+    assert_equal 10, categories(:supermarket).recent_transactions.count
+  end
+
+  test "recent_transactions are ordered by booked_at descending" do
+    older = Transaction.create!(
+      amount: 40,
+      booked_at: 50.days.from_now,
+      interest_at: 50.days.from_now,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+    newer = Transaction.create!(
+      amount: 50,
+      booked_at: 51.days.from_now,
+      interest_at: 51.days.from_now,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+
+    result_ids = categories(:supermarket).recent_transactions(limit: 2).pluck(:id)
+
+    assert_equal [ newer.id, older.id ], result_ids
+  end
+
+  test "recent_transactions break booked_at ties with newest record first" do
+    timestamp = 70.days.from_now
+
+    first = Transaction.create!(
+      amount: 60,
+      booked_at: timestamp,
+      interest_at: timestamp,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+    second = Transaction.create!(
+      amount: 70,
+      booked_at: timestamp,
+      interest_at: timestamp,
+      debitor: accounts(:checking),
+      creditor: accounts(:albert_heijn),
+      category: categories(:supermarket)
+    )
+
+    result_ids = categories(:supermarket).recent_transactions(limit: 2).pluck(:id)
+
+    assert_equal [ second.id, first.id ], result_ids
+  end
+
+  test "recent_transactions preloads associations used by the view" do
+    relation = categories(:supermarket).recent_transactions
+
+    assert_includes relation.includes_values, :creditor
+    assert_includes relation.includes_values, :debitor
+    assert_includes relation.includes_values, :category
+  end
+
   # -- to_s -------------------------------------------------------------------
 
   test "to_s returns the name" do


### PR DESCRIPTION
This adds a reusable recent-transactions table partial to account and category show/edit pages. It introduces `Account#recent_transactions` and `Category#recent_transactions` with deterministic ordering and eager loading, and category recent transactions now include child-category transactions for parent pages. It also adds the `transactions.recent.heading` locale key for EN/IT/NL and expands model + integration coverage for inclusion, limits, ordering, tie-breaking, and page rendering. Validation: full test suite passes (238 tests) via pre-push hooks.