### PR TITLE
chore(deps): add dependabot config with 1-week cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering bundler, npm, and github-actions ecosystems
- Weekly schedule with a 7-day cooldown per ecosystem to batch updates

## Test plan
- [ ] Verify dependabot picks up the config on the default branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)