### PR TITLE
Update mvpa-css to 524c8af (SMACSS fix, monochrome, float flash)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/eirvandelden/mvpa.css.git
-  revision: bc9d982b8d62c6817928633758fe40d0a561f57e
+  revision: 524c8af99ef7a298aa59d3b5c34a83ba2ceecdd7
   specs:
-    mvpa-css (0.1.0.pre.git.bc9d982)
+    mvpa-css (0.1.0.pre.git.524c8af)
       railties (>= 6.0)
 
 GEM
@@ -576,7 +576,7 @@ CHECKSUMS
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
-  mvpa-css (0.1.0.pre.git.bc9d982)
+  mvpa-css (0.1.0.pre.git.524c8af)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/app/assets/stylesheets/local/modules/flash.css
+++ b/app/assets/stylesheets/local/modules/flash.css
@@ -1,4 +1,4 @@
-output[data-mvpa-flashes] {
+section[data-mvpa-flashes] {
   top: unset;
   bottom: var(--block-space);
 }

--- a/app/assets/stylesheets/local/modules/flash.css
+++ b/app/assets/stylesheets/local/modules/flash.css
@@ -1,0 +1,4 @@
+output[data-mvpa-flashes] {
+  top: unset;
+  bottom: var(--block-space);
+}

--- a/app/assets/stylesheets/local/modules/index.css
+++ b/app/assets/stylesheets/local/modules/index.css
@@ -1,4 +1,5 @@
 @import url("buttons.css");
+@import url("flash.css");
 @import url("pagination.css");
 @import url("form_errors.css");
 @import url("search_dialog.css");

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -24,14 +24,16 @@
     </header>
 
     <main>
-      <section data-mvpa-flashes>
-        <% if flash[:notice] %>
-          <aside role="status"><%= flash[:notice] %></aside>
-        <% end %>
-        <% if flash[:alert] %>
-          <aside role="alert"><%= flash[:alert] %></aside>
-        <% end %>
-      </section>
+      <% if flash.any? %>
+        <section data-mvpa-flashes>
+          <% if flash[:notice] %>
+            <aside role="status"><%= flash[:notice] %></aside>
+          <% end %>
+          <% if flash[:alert] %>
+            <aside role="alert"><%= flash[:alert] %></aside>
+          <% end %>
+        </section>
+      <% end %>
 
       <%= yield %>
     </main>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -24,13 +24,14 @@
     </header>
 
     <main>
-      <% if flash[:notice] %>
-        <p role="status"><%= flash[:notice] %></p>
-      <% end %>
-
-      <% if flash[:alert] %>
-        <p role="alert"><%= flash[:alert] %></p>
-      <% end %>
+      <output data-mvpa-flashes>
+        <% if flash[:notice] %>
+          <aside role="status"><%= flash[:notice] %></aside>
+        <% end %>
+        <% if flash[:alert] %>
+          <aside role="alert"><%= flash[:alert] %></aside>
+        <% end %>
+      </output>
 
       <%= yield %>
     </main>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -24,14 +24,14 @@
     </header>
 
     <main>
-      <output data-mvpa-flashes>
+      <section data-mvpa-flashes>
         <% if flash[:notice] %>
           <aside role="status"><%= flash[:notice] %></aside>
         <% end %>
         <% if flash[:alert] %>
           <aside role="alert"><%= flash[:alert] %></aside>
         <% end %>
-      </output>
+      </section>
 
       <%= yield %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="selenized_light" data-color-scheme="system">
+<html data-theme="solunized-light" data-color-scheme="system">
   <head>
     <title>JournalAdministration</title>
     <%= csrf_meta_tags %>
@@ -47,11 +47,11 @@
       </nav>
     </header>
     <main>
-      <% flash.each do |key, value| %>
-        <aside>
-          <p role="<%= key.to_s == 'alert' || key.to_s == 'error' ? 'alert' : 'status' %>"><%= value %></p>
-        </aside>
-      <% end %>
+      <output data-mvpa-flashes>
+        <% flash.each do |key, value| %>
+          <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
+        <% end %>
+      </output>
       <%= yield %>
     </main>
     <dialog id="confirm-dialog">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,11 +47,11 @@
       </nav>
     </header>
     <main>
-      <output data-mvpa-flashes>
+      <section data-mvpa-flashes>
         <% flash.each do |key, value| %>
           <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
         <% end %>
-      </output>
+      </section>
       <%= yield %>
     </main>
     <dialog id="confirm-dialog">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,11 +47,13 @@
       </nav>
     </header>
     <main>
-      <section data-mvpa-flashes>
-        <% flash.each do |key, value| %>
-          <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
-        <% end %>
-      </section>
+      <% if flash.any? %>
+        <section data-mvpa-flashes>
+          <% flash.each do |key, value| %>
+            <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
+          <% end %>
+        </section>
+      <% end %>
       <%= yield %>
     </main>
     <dialog id="confirm-dialog">

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -11,11 +11,11 @@
   </head>
   <body>
     <main>
-      <output data-mvpa-flashes>
+      <section data-mvpa-flashes>
         <% flash.each do |key, value| %>
           <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
         <% end %>
-      </output>
+      </section>
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -11,11 +11,13 @@
   </head>
   <body>
     <main>
-      <section data-mvpa-flashes>
-        <% flash.each do |key, value| %>
-          <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
-        <% end %>
-      </section>
+      <% if flash.any? %>
+        <section data-mvpa-flashes>
+          <% flash.each do |key, value| %>
+            <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
+          <% end %>
+        </section>
+      <% end %>
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="selenized_light" data-color-scheme="system">
+<html data-theme="solunized-light" data-color-scheme="system">
   <head>
     <title>JournalAdministration</title>
     <%= csrf_meta_tags %>
@@ -11,11 +11,11 @@
   </head>
   <body>
     <main>
-      <% flash.each do |key, value| %>
-        <aside>
-          <p role="<%= key.to_s == 'alert' || key.to_s == 'error' ? 'alert' : 'status' %>"><%= value %></p>
-        </aside>
-      <% end %>
+      <output data-mvpa-flashes>
+        <% flash.each do |key, value| %>
+          <aside role="<%= key.to_s.in?(%w[alert error]) ? 'alert' : 'status' %>"><%= value %></aside>
+        <% end %>
+      </output>
       <%= yield %>
     </main>
   </body>


### PR DESCRIPTION
Bumps the `mvpa-css` gem from `bc9d982` to `524c8af`. The new version restructures the SMACSS folder layout, adds `@media (monochrome)` support for e-ink displays, and changes flash messages to fixed-position toasts using a `[data-mvpa-flashes]` container.

All three layouts are updated to use `<output data-mvpa-flashes>` (semantic wrapper for live feedback) with `role` moved from `<p>` to `<aside>`, matching the new flash.css selectors. The stale `data-theme="selenized_light"` attribute is corrected to `solunized-light`.