### PR TITLE
Configure SQLite pragmas to reduce database lock contention

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -40,8 +40,15 @@ default: &default
   pool: <%= ENV['RAILS_MAX_THREADS'] || 5 %>
   host: <%= ENV['DOCKER_DB_HOST'] || 'localhost' %>
   port: <%= ENV['DOCKER_DB_PORT'] || 5432 %>
-  timeout: 10000
+  timeout: 5000
   default_transaction_mode: immediate
+  pragmas:
+    journal_mode: wal
+    wal_autocheckpoint: 10000
+    synchronous: normal
+    temp_store: memory
+    mmap_size: 134217728
+    cache_size: -20000
 
 development:
   <<: *default
@@ -56,6 +63,13 @@ test:
   <<: *default
   # database: storage/test.sqlite3
   database: storage/db/test.sqlite3
+  timeout: 20000
+  pragmas:
+    journal_mode: wal
+    synchronous: "off"
+    temp_store: memory
+    mmap_size: 268435456
+    cache_size: -20000
 
 production:
   <<: *default


### PR DESCRIPTION
## Summary
- Set `journal_mode: wal`, `synchronous: normal`, `temp_store: memory`, `cache_size: -20000`, `mmap_size: 128MB`, and `wal_autocheckpoint: 10000` on the shared `default:` anchor in `config/database.yml` so production and development share one source of truth (and any future Solid Queue/Cache/Cable databases inherit it automatically).
- Lowered production/development `timeout` to 5000ms; test overrides with a 20000ms timeout, `synchronous: off`, and a 256MB `mmap_size` to tolerate parallel test-runner contention without slowing down disposable test writes.
- Deliberately did not add a `pragmas.busy_timeout` — Rails' existing `timeout:` key already installs a GVL-friendly busy handler, and the native pragma would replace it with a GVL-blocking one, which is worse under threaded Puma.

## Test plan
- [x] `bin/rails runner` confirms pragmas apply in both development and test environments
- [x] `bin/rails test` — 611 runs, 0 failures
- [x] Pre-push hooks (brakeman, bundler_audit, herb, rubocop) all clean