### PR TITLE
Redirect to chattels index after creating a chattel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,7 +435,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -667,7 +667,7 @@ CHECKSUMS
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
-  websocket-driver (0.8.1) sha256=5ab238238ce230e5d4b262d2be39624c867914eab99171dc4952b58b577c2d96
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12

--- a/app/controllers/chattels_controller.rb
+++ b/app/controllers/chattels_controller.rb
@@ -43,7 +43,7 @@ class ChattelsController < ApplicationController
 
     respond_to do |format|
       if @chattel.save
-        format.html { redirect_to @chattel, notice: t("chattels.create.success") }
+        format.html { redirect_to chattels_path, notice: t("chattels.create.success") }
         format.json { render :show, status: :created, location: @chattel }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/test/controllers/chattels_controller_test.rb
+++ b/test/controllers/chattels_controller_test.rb
@@ -47,7 +47,7 @@ class ChattelsControllerTest < ActionDispatch::IntegrationTest
            params: { chattel: chattel_params }
     end
 
-    assert_redirected_to chattel_url(Chattel.last)
+    assert_redirected_to chattels_url
   end
 
   test "should show chattel" do

--- a/test/system/chattels_test.rb
+++ b/test/system/chattels_test.rb
@@ -21,7 +21,7 @@ class ChattelsTest < ApplicationSystemTestCase
     click_on I18n.t("common.save", locale: @locale)
 
     assert_text "Chattel was successfully created"
-    click_on I18n.t("common.back", locale: @locale)
+    assert_text "System Test Chattel"
   end
 
   test "should update Chattel" do


### PR DESCRIPTION
## Summary
- Redirects to the chattels index instead of the new record's show page after a successful create, matching the pattern already used by destroy.
- Updates the controller test to assert the redirect goes to `chattels_url`.
- Updates the system test to check the new chattel appears in the index instead of clicking a "back" link (which lived on the show page).
- Bumps `websocket-driver` to 0.8.2 to fix GHSA-2x63-gw47-w4mm, flagged by bundler-audit on push.

## Test plan
- [x] `bin/rails test test/controllers/chattels_controller_test.rb` (10/10 passing)
- [x] Full test suite via pre-push hook (611 runs, 0 failures)
- [x] RuboCop, Brakeman, Herb, bundler-audit all clean