### PR TITLE
Add viewport meta tag and make header padding responsive

### DIFF
--- a/app/assets/stylesheets/local/layout/application_page.css
+++ b/app/assets/stylesheets/local/layout/application_page.css
@@ -1,6 +1,8 @@
 /* Page layout customizations */
-body > header {
-  padding: 1rem;
+@media (min-width: 769px) {
+  body > header {
+    padding: 1rem;
+  }
 }
 
 body > main {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html data-theme="solunized-light" data-color-scheme="system">
   <head>
     <title>JournalAdministration</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
Adds a viewport meta tag so mobile browsers render at device width. Wraps the header padding in a `@media (min-width: 769px)` rule so it only applies on wider screens. Theme names (`solunized-light`, `data-color-scheme="system"`) were verified against the mvpa.css gem and are correct.