### PR TITLE
fix: skip Campfire notifier install when webhook URL is absent

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if Rails.env.production?
+if Rails.env.production? && ENV["CAMPFIRE_WEBHOOK_URL"].present?
   ExceptionNotification::Once::Campfire.install!(
     webhook_url: ENV.fetch("CAMPFIRE_WEBHOOK_URL"),
     app_name: ENV.fetch("APP_NAME", Rails.application.class.module_parent_name),


### PR DESCRIPTION
## Summary
- Docker build's `assets:precompile` step boots Rails in production mode without runtime secrets (Kamal only injects `env.secret` values like `CAMPFIRE_WEBHOOK_URL` at container runtime, not build time), so `ENV.fetch("CAMPFIRE_WEBHOOK_URL")` raised `KeyError` and aborted the build.
- Guard the Campfire exception notifier install behind `ENV["CAMPFIRE_WEBHOOK_URL"].present?` so it's skipped when the var is absent (build stage), and still installs normally at runtime once Kamal injects the real secret.

## Test plan
- [x] `bundle exec rubocop` clean
- [x] Full test suite (627 runs) green
- [ ] Confirm deploy build no longer fails on `assets:precompile`