### PR TITLE
Update all Ruby and JavaScript dependencies

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,4 +1,4 @@
-version: 0.8.10
+version: 0.10.3
 
 files:
   exclude:
@@ -32,6 +32,12 @@ linter:
     parser-no-errors:
       enabled: true
       severity: error
+    actionview-no-silent-helper:
+      enabled: false
+    erb-no-output-in-attribute-name:
+      enabled: false
+    erb-prefer-direct-output:
+      enabled: false
 
 formatter:
   enabled: false

--- a/.herb.yml
+++ b/.herb.yml
@@ -33,11 +33,14 @@ linter:
       enabled: true
       severity: error
     actionview-no-silent-helper:
-      enabled: false
+      enabled: true
+      severity: error
     erb-no-output-in-attribute-name:
-      enabled: false
+      enabled: true
+      severity: error
     erb-prefer-direct-output:
-      enabled: false
+      enabled: true
+      severity: error
 
 formatter:
   enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/eirvandelden/appkit.git
-  revision: 822925bfedef9c71f568ce82300de9f2da4b7901
+  revision: e131f65e8d1eec72011ad19d3ed4106baa177eb4
   specs:
-    appkit (0.1.0.pre.git.822925b)
+    appkit (0.1.0.pre.git.e131f65)
       importmap-rails (>= 1.0)
       okcomputer (~> 1.19)
       railties (>= 8.0)
@@ -19,9 +19,9 @@ GIT
 
 GIT
   remote: https://github.com/eirvandelden/mvpa.css.git
-  revision: 0d76db0d74cae5120883cd22f15775f3afd8dd2d
+  revision: e39a6280aa3dc4c51ed29f9e95b4f80e11e3b4ea
   specs:
-    mvpa-css (0.1.0.pre.git.0d76db0)
+    mvpa-css (0.1.0.pre.git.e39a628)
       railties (>= 6.0)
 
 GEM
@@ -110,9 +110,9 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.6)
-      msgpack (~> 1.2)
-    brakeman (8.0.5)
+    bootsnap (1.25.0)
+      msgpack (~> 1.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -132,7 +132,7 @@ GEM
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
-    csv (3.3.5)
+    csv (3.3.6)
     data_migrate (11.3.1)
       activerecord (>= 6.1)
       railties (>= 6.1)
@@ -146,9 +146,9 @@ GEM
       railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
-    erb (6.0.5)
+    erb (6.0.7)
     erubi (1.13.1)
-    et-orbi (1.4.0)
+    et-orbi (1.4.1)
       tzinfo
     exception_notification (5.0.1)
       actionmailer (>= 7.1, < 9)
@@ -162,16 +162,16 @@ GEM
       addressable (>= 2.5.0)
     globalid (1.4.0)
       activesupport (>= 6.1)
-    herb (0.10.2)
-    herb (0.10.2-aarch64-linux-gnu)
-    herb (0.10.2-aarch64-linux-musl)
-    herb (0.10.2-arm-linux-gnu)
-    herb (0.10.2-arm-linux-musl)
-    herb (0.10.2-arm64-darwin)
-    herb (0.10.2-x86-linux-gnu)
-    herb (0.10.2-x86_64-darwin)
-    herb (0.10.2-x86_64-linux-gnu)
-    herb (0.10.2-x86_64-linux-musl)
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86-linux-gnu)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
     highline (3.1.2)
       reline
     i18n (1.15.2)
@@ -192,7 +192,7 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -222,21 +222,21 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
     marcel (1.2.1)
-    matrix (0.4.2)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.3)
-    net-imap (0.6.4.1)
+    msgpack (1.8.4)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -289,9 +289,9 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
-    raabro (1.4.0)
+    raabro (1.5.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -339,7 +339,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.0.3)
+    rbs (4.1.3)
       logger
       prism (>= 1.6.0)
       tsort
@@ -350,17 +350,17 @@ GEM
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.26.4)
+    redis-client (0.30.1)
       connection_pool
     regexp_parser (2.12.0)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     rexml (3.4.4)
     rqrcode (2.2.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
     rqrcode_core (1.2.0)
-    rubocop (1.88.2)
+    rubocop (1.89.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -377,7 +377,7 @@ GEM
     rubocop-capybara (3.0.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
-    rubocop-minitest (0.39.1)
+    rubocop-minitest (0.40.0)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
@@ -409,13 +409,13 @@ GEM
     ruby-progressbar (1.13.0)
     rubyzip (3.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.45.0)
+    selenium-webdriver (4.47.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    solid_queue (1.4.0)
+    solid_queue (1.6.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
       concurrent-ruby (>= 1.3.1)
@@ -433,7 +433,7 @@ GEM
     sqlite3 (2.9.6-x86_64-darwin)
     sqlite3 (2.9.6-x86_64-linux-gnu)
     sqlite3 (2.9.6-x86_64-linux-musl)
-    sshkit (1.25.0)
+    sshkit (1.25.1)
       base64
       logger
       net-scp (>= 1.1.2)
@@ -446,11 +446,11 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
-    thruster (0.1.23)
-    thruster (0.1.23-aarch64-linux)
-    thruster (0.1.23-arm64-darwin)
-    thruster (0.1.23-x86_64-darwin)
-    thruster (0.1.23-x86_64-linux)
+    thruster (0.1.25)
+    thruster (0.1.25-aarch64-linux)
+    thruster (0.1.25-arm64-darwin)
+    thruster (0.1.25-x86_64-darwin)
+    thruster (0.1.25-x86_64-linux)
     timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.23)
@@ -477,7 +477,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.2)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   aarch64-linux
@@ -553,7 +553,7 @@ CHECKSUMS
   activestorage (8.1.3.1) sha256=f555254f387b1cffa499d2fd3115d12635eadc5b15206a8534316a67036163ef
   activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  appkit (0.1.0.pre.git.822925b)
+  appkit (0.1.0.pre.git.e131f65)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
@@ -561,8 +561,8 @@ CHECKSUMS
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  bootsnap (1.25.0) sha256=41059e7d0f9cb4023a33465d095f64b913fc9d1b808d6524c307da945fbcffcf
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
@@ -571,7 +571,7 @@ CHECKSUMS
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
-  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
   data_migrate (11.3.1) sha256=18b9b2189d15e482d5335f3fc2248b8b447204bd8257ded872dd077737168ffb
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
@@ -579,30 +579,30 @@ CHECKSUMS
   dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
-  erb (6.0.5) sha256=858e63488cb796c9daba8b6e9ff4b3879c395022049be9a66a8e00980e612eac
+  erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  et-orbi (1.4.1) sha256=007e2685b1d873415a7587ef889336c6dcdf8a47fc9c9a63547582b21660a11b
   exception_notification (5.0.1) sha256=a9698c8d4670ec50f1714fd14a61a9f83da082d3b5535fd830baf3dc75ba28f9
   exception_notification-campfire-once (0.1.0.pre.git.8472c72)
   flutie (2.2.1) sha256=4b461043d086aa085f8e294780564c51571e08a50996cc0a85734dbdf46fedfc
   fugit (1.13.0) sha256=a4f093fce740da52f216740a5041e2a594ea763cdb89e8b2754ca4399634ab18
   geared_pagination (1.2.0) sha256=16dc25b28e9d6945df27e9bcc6ed298d66eb9493ba45bf987037010724120cc7
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
-  herb (0.10.2) sha256=77c3d93b2a2e9890df345bee30cb1922231dbd4a1740021d15fbba4dafb3b83f
-  herb (0.10.2-aarch64-linux-gnu) sha256=7888e560a9eaede00db65475981858b0d7be287ea72686360a3a11a86d6a8011
-  herb (0.10.2-aarch64-linux-musl) sha256=23b546d207b813879373a439a39cf2de233e04b65671e436c59fd8644b173632
-  herb (0.10.2-arm-linux-gnu) sha256=d716692557de6d0441e9b1053f1a953b7025d7555de0e9fd2458e7f2382f0211
-  herb (0.10.2-arm-linux-musl) sha256=09de8e03d686ee32585fafde618ae25f62e5556c1afe3afdb5b55cb2c9f6a151
-  herb (0.10.2-arm64-darwin) sha256=49c89173478c83e3de241fc7d2c52892d1b788fd26076ba25dd2399656d7f561
-  herb (0.10.2-x86-linux-gnu) sha256=319eee8a1b9c1a57d5ce8bba1ce7704de3db3cf56f2820fc4f52036f36c7e581
-  herb (0.10.2-x86_64-darwin) sha256=b79c538c77506e21abeae80fca3eb14a700a35aae8e99a326ea5948a95fc821e
-  herb (0.10.2-x86_64-linux-gnu) sha256=7042322268a83c62bed32a5be4b64e0f4716c88d45a6ac372e839d646711a863
-  herb (0.10.2-x86_64-linux-musl) sha256=c91182c8b75431fe6a77c7a776f8be7db4b9a245ee95821f943e8d3725242664
+  herb (0.10.3) sha256=da76e8bfbb302586ee51a4fb608624f48218fbfea198a9493540b42f7654024b
+  herb (0.10.3-aarch64-linux-gnu) sha256=1eaea87e6577557492a1b0ddaae989fba8a8ddd382e888ee5f939ce6ded06eb8
+  herb (0.10.3-aarch64-linux-musl) sha256=4ac7ccd194f8f284ffc7bf093676f5194cf0f44ea4a7d3888eac095e81c43e1f
+  herb (0.10.3-arm-linux-gnu) sha256=d5f007b665a705b5566f1068b54e1600d5ffe6cb0b7d274e27dd7ed5918ca54e
+  herb (0.10.3-arm-linux-musl) sha256=09a0979f64ee3aff0b25a345c2cecd15992a0532295fd00249d73f13a3e313b1
+  herb (0.10.3-arm64-darwin) sha256=1a5bef57d925d775496328e7a01a9c1260e1d83bed8038b60a4f8c81b12c15a3
+  herb (0.10.3-x86-linux-gnu) sha256=3d8a4b6cc0398bef40382fa00c565bfd6f0ba31bf91ff9362d4348dcd9715879
+  herb (0.10.3-x86_64-darwin) sha256=e02e43b3bb1977f4fd08f3330b5f2aa3292ca2d572a8bd59688eca8b79725f46
+  herb (0.10.3-x86_64-linux-gnu) sha256=cbb49b66f2bdc92d17109d1ea9452e88ba6a8ae52e9ddd5279deff83dcc4c66d
+  herb (0.10.3-x86_64-linux-musl) sha256=c84482d6b57f13c2e1a0fa029649efb0e5fdc876a3fd564bae09cf42bd4d5ae1
   highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   i18n-tasks (1.1.2) sha256=4dcfba49e52a623f30661cb316cb80d84fbba5cb8c6d88ef5e02545fffa3637a
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
-  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.15.1) sha256=2430bec28fb0cebacb5875b1009cf9d8bc3c303ccb810c4c8b062a4b51457637
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
@@ -613,15 +613,15 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
-  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
-  matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
-  mvpa-css (0.1.0.pre.git.0d76db0)
-  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
+  msgpack (1.8.4) sha256=4411c22d350dd1c20250f7eada3cca2695438c2f769cf0782f0cd065d90a3e7b
+  mvpa-css (0.1.0.pre.git.e39a628)
+  net-imap (0.6.6) sha256=96aa4ee50df3060203e649efc341f53480b791d49e150f2fdebf68beb141a8df
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d
@@ -649,9 +649,9 @@ CHECKSUMS
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
-  raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
+  raabro (1.5.0) sha256=3f998a7bc84f9c84df3ab580634d2e0a5bda4f0841168d56035f529c9877440a
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
@@ -663,19 +663,19 @@ CHECKSUMS
   railties (8.1.3.1) sha256=2388a232579a00cefea4487de66c8553c3408c1300abdc6cf1799d86ffb04487
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
-  redis-client (0.26.4) sha256=3ad70beff5da2653e02dfeae996e7d8d7147a558da12b16b2282ad345e4c7120
+  redis-client (0.30.1) sha256=5151bc5c7bbfe48623732cdae3b900d8a22dc691cc7cdfacfb351ac55116522d
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rqrcode (2.2.0) sha256=23eea88bb44c7ee6d6cab9354d08c287f7ebcdc6112e1fe7bcc2d010d1ffefc1
   rqrcode_core (1.2.0) sha256=cf4989dc82d24e2877984738c4ee569308625fed2a810960f1b02d68d0308d1a
-  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop (1.89.0) sha256=4dee8e3ee9c45e474834efd9e8d6fd031e8331c8dacdff0de4ad65ae0a6faae7
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-capybara (3.0.0) sha256=7a64655238acda7f8f3c87e37ac825a64c615a79c17c253f1a28270dc3768c4b
-  rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
+  rubocop-minitest (0.40.0) sha256=353c698199115f12151144cf0b5a96f69bb9d77b660cf6536df2c4250c672a9d
   rubocop-obsession (0.2.3) sha256=db35c9c2673d107c578e905c36e98f6d7c7e038e4d9afe27479e7e3dee06cc89
   rubocop-packaging (0.6.0) sha256=fb92bd0fb48e6f8cdb1648d2249b0cd51c2497dcc87340132d22f01edbf558a7
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
@@ -685,8 +685,8 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (3.4.1) sha256=0a79e745b5c25872ebd148457df5665da8530ed8626c993b01457128f173ca02
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  selenium-webdriver (4.45.0) sha256=ecac65a4df86ac6f7d707e6dcbacaa9c08b6cf2b966babecfb9653c5aa13e2d1
-  solid_queue (1.4.0) sha256=e6a18d196f0b27cb6e3c77c5b31258b05fb634f8ed64fb1866ed164047216c2a
+  selenium-webdriver (4.47.0) sha256=67f915b8223d2133bbaa13e92fd98854175394f086e2036a9eff4f5561fd69e4
+  solid_queue (1.6.0) sha256=b5fc3bb34162e09d8f960df6400d0f9304dc80fe66c2cfface31c32b228de6a1
   sqlite3 (2.9.6) sha256=956fe606956420d04ac7157d3ace620c8caba2135b2e05c76e483493da24d08e
   sqlite3 (2.9.6-aarch64-linux-gnu) sha256=d8b1f7d23efd7abac285775a9566562fc7debfef79d594e3a20354406fb7907c
   sqlite3 (2.9.6-aarch64-linux-musl) sha256=3579e1c98cdc7ff5c3722847bb63ed4e1efb7ff675cb5e1e48ef2d4da5fb3bc9
@@ -697,16 +697,16 @@ CHECKSUMS
   sqlite3 (2.9.6-x86_64-darwin) sha256=b5842fea77781c14da03fa7bc0feb82db03a69e135affcb6f5399cbd2797a5f3
   sqlite3 (2.9.6-x86_64-linux-gnu) sha256=613188ce02f614126ddbc38c5e217ccffd6306d0dcd9adca9764547aa890a634
   sqlite3 (2.9.6-x86_64-linux-musl) sha256=d493b11818a3573387a1d56e1ee8fa00da23a683a7a1cc063e7a0feeed843abf
-  sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
+  sshkit (1.25.1) sha256=be3f10b9d6eb0b44d5eaba3f7cbe41bc6bb894bce4339688ac20124391455b78
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   symbol-fstring (1.0.2) sha256=8936dbeaa05a3ee665109055daa1ab9517af0c71ea80c4d52cf6842e0f68ddf4
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
-  thruster (0.1.23) sha256=ad3081e8ff3b5cb413768292c367f1e015c423bb6b35919b9b9f533af50d639f
-  thruster (0.1.23-aarch64-linux) sha256=042a05581dd1d750d1583d83817460b1f7fde254ed0b2bcd7ec56f9bed278c7a
-  thruster (0.1.23-arm64-darwin) sha256=2f1b73119ffec813cdb104d64dd39bfc3771b5308eb0f4dc2428077141140022
-  thruster (0.1.23-x86_64-darwin) sha256=2b22a951f6ac1218c9f461bfc6004b61854147308649475a07bc05fae2e69869
-  thruster (0.1.23-x86_64-linux) sha256=9cd7265bf54e954575c8442e42d050ed8eb55df4f9d7da8fd6f94fcc0339baa5
+  thruster (0.1.25) sha256=d97d704e91fa37d5858bc238dea6186f7310b633abfeea9f2ba814f252203716
+  thruster (0.1.25-aarch64-linux) sha256=495265b11fc3c3596ae0d70ed902b60db82dafb2a5b47a2c527d3176ee3cf311
+  thruster (0.1.25-arm64-darwin) sha256=20338360cce4035e787135ae154a10663f3d3d61b15bfa72df347fe9d982de57
+  thruster (0.1.25-x86_64-darwin) sha256=633d337baee05e8eacbc18e3986ea6bbf8ea237abd67f5e4351b8aa710623c5e
+  thruster (0.1.25-x86_64-linux) sha256=e5586003b34dc2f4200f8412101e906621e276bb294d41d1b63a3c41e348503d
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
@@ -721,7 +721,7 @@ CHECKSUMS
   websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
-  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
+  zeitwerk (2.8.3) sha256=2c85125a8467ce069e20123d1e709a08955c9d29c118c25b46b7b7fafdbb92e5
 
 RUBY VERSION
    ruby 4.0.5p0

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -1,0 +1,13 @@
+# Helpers for rendering the todo list.
+module TodosHelper
+  # Renders a todo item's description: the outstanding note and amount for a
+  # transaction, or the account's name.
+  #
+  # @param item [Todo::Item] the todo item
+  # @return [String] the description
+  def todo_description(item)
+    return item.record.to_s unless item.kind == :transaction
+
+    safe_join([ item.record.note&.truncate(40), number_to_currency(item.record.uncategorized_amount) ].compact, " ")
+  end
+end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
-<html <%= tag.attributes(theme_attributes) %> data-controller="theme">
+<html
+  data-controller="theme"
+  data-color-scheme="<%= theme_attributes[:"data-color-scheme"] %>"
+  data-light-theme="<%= theme_attributes[:"data-light-theme"] %>"
+  data-dark-theme="<%= theme_attributes[:"data-dark-theme"] %>"
+  data-theme="<%= theme_attributes[:"data-theme"] %>"
+>
   <head>
     <title>Admin - <%= Rails.application.class.module_parent_name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
-<html <%= tag.attributes(theme_attributes) %> data-controller="theme">
+<html
+  data-controller="theme"
+  data-color-scheme="<%= theme_attributes[:"data-color-scheme"] %>"
+  data-light-theme="<%= theme_attributes[:"data-light-theme"] %>"
+  data-dark-theme="<%= theme_attributes[:"data-dark-theme"] %>"
+  data-theme="<%= theme_attributes[:"data-theme"] %>"
+>
   <head>
     <title>JournalAdministration</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -15,11 +15,6 @@
       <tbody>
         <% @items.each do |item| %>
           <% kind = item.kind == :transaction ? t(".transaction") : t(".account") %>
-          <% description = if item.kind == :transaction
-                             safe_join([ item.record.note&.truncate(40), number_to_currency(item.record.uncategorized_amount) ].compact, " ")
-                           else
-                             item.record.to_s
-                           end %>
           <% actions = capture do %>
             <% if item.kind == :transaction %>
               <%= link_to t(".edit"), edit_transaction_path(item.record) %>
@@ -31,7 +26,7 @@
           <tr>
             <td><%= l item.date, format: :short %></td>
             <td><%= kind %></td>
-            <td><%= description %></td>
+            <td><%= todo_description(item) %></td>
             <td><%= actions %></td>
           </tr>
         <% end %>

--- a/app/views/transactions/edit.html.erb
+++ b/app/views/transactions/edit.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <h1><%= "#{@transaction.creditor} ➡️ #{@transaction.debitor}" %></h1>
+  <h1><%= @transaction.creditor %> ➡️ <%= @transaction.debitor %></h1>
   <nav>
     <%= link_to @transaction do %>
       <b><%= t('common.show') %></b>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <h1><%= "#{@transaction.creditor} ➡️ #{@transaction.debitor}" %></h1>
+  <h1><%= @transaction.creditor %> ➡️ <%= @transaction.debitor %></h1>
   <nav>
     <%= link_to edit_transaction_path(@transaction) do %>
       <b><%= t('common.edit') %></b>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,56 +6,60 @@
     "": {
       "name": "little-rock",
       "devDependencies": {
-        "@herb-tools/linter": "^0.10.2"
+        "@herb-tools/linter": "^0.10.3"
       }
     },
     "node_modules/@herb-tools/config": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/config/-/config-0.10.2.tgz",
-      "integrity": "sha512-hNyNpspNoeiwO7VEorXrr827byq8hCMk6jP24X5d/RAVoVlzlRssqux5zDu3d8MG69J+Zb4EN3hkPDiVhkkELw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/config/-/config-0.10.3.tgz",
+      "integrity": "sha512-cSaOwuWnij1wiB4Xh9Zfx/s+lhis7cN/+PXssanT/mXQLSRU2QeYasivyCQ1tRnpIVdGGOC/rqHVJQeNmj4pqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@herb-tools/core": "0.10.2",
+        "@herb-tools/core": "0.10.3",
         "picomatch": "^4.0.5",
         "tinyglobby": "^0.2.16",
         "yaml": "^2.9.0"
       }
     },
     "node_modules/@herb-tools/core": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/core/-/core-0.10.2.tgz",
-      "integrity": "sha512-gAZjcgFO0UcQXiRG1hkPAnn6SAX/Jj//Bq2QcFUCLMcbAY0uaF13g7QDiY+ntg9LqmdT5Lka0TXC8mv1ehTk8w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@herb-tools/highlighter": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/highlighter/-/highlighter-0.10.2.tgz",
-      "integrity": "sha512-dO73MHogYflARek8PZQ/TYCkIeXxB353/KA+/w0fPf18jmNGVpHc6J1hC+Lsqo+k4runjCmvaPLN7ETWoI/ndA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/core/-/core-0.10.3.tgz",
+      "integrity": "sha512-rtDoh6C/EMYLEtFwYpuY+IlnV7PLsF5hQszq7uMDE/bwEpLVBlPFd2Wlk9E0RB31PVQKV1MwgGqstte87XqF9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@herb-tools/core": "0.10.2",
-        "@herb-tools/node-wasm": "0.10.2"
+        "@ruby/prism": "^1.9.0"
+      }
+    },
+    "node_modules/@herb-tools/highlighter": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/highlighter/-/highlighter-0.10.3.tgz",
+      "integrity": "sha512-vyBPl/oWalPcXrhni6RrQzeizzC0i7An3yMAg/Xx+4HDhgU/zOlRqSUYLU7SpzjfK4OU5QhRDdc3OBI8dT5qmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.3",
+        "@herb-tools/node-wasm": "0.10.3"
       },
       "bin": {
         "herb-highlight": "bin/herb-highlight"
       }
     },
     "node_modules/@herb-tools/linter": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/linter/-/linter-0.10.2.tgz",
-      "integrity": "sha512-0B8kT3jrSJwwmjjW0IFOreloF/9yrGm9ti931TxVG54u0PYDNI8ONRLub0sSzbPlKqPFtJXhjN7lPRqQdGz3Ow==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/linter/-/linter-0.10.3.tgz",
+      "integrity": "sha512-uNwJZkzswJ/IcpsjbuEzOXQQcfc40KGy8Ao1L69na2J6H7b4LFig2OIZ22vJasGdv4jODWJWnMDozRvWuv1vFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@herb-tools/config": "0.10.2",
-        "@herb-tools/core": "0.10.2",
-        "@herb-tools/highlighter": "0.10.2",
-        "@herb-tools/node-wasm": "0.10.2",
-        "@herb-tools/printer": "0.10.2",
-        "@herb-tools/rewriter": "0.10.2",
+        "@herb-tools/config": "0.10.3",
+        "@herb-tools/core": "0.10.3",
+        "@herb-tools/highlighter": "0.10.3",
+        "@herb-tools/node-wasm": "0.10.3",
+        "@herb-tools/printer": "0.10.3",
+        "@herb-tools/rewriter": "0.10.3",
+        "@ruby/prism": "^1.9.0",
         "picomatch": "^4.0.5",
         "tinyglobby": "^0.2.15"
       },
@@ -64,23 +68,24 @@
       }
     },
     "node_modules/@herb-tools/node-wasm": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/node-wasm/-/node-wasm-0.10.2.tgz",
-      "integrity": "sha512-gSu674UiuxCL5ypQveQqGd4GMk+iKSmI7Hk2nLIs/L132exrfumVg+Jxd+Nqg6z7lzDbx+/yXLKdMoLIh1OFaw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/node-wasm/-/node-wasm-0.10.3.tgz",
+      "integrity": "sha512-KUwHUMB6kluyvRiW0A9wbTiuO/qlvXLlSAnewmH2za7yePvYRSiThfAZEmXPqEmpmMRcIksFxaNaxUc6nBqyuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@herb-tools/core": "0.10.2"
+        "@herb-tools/core": "0.10.3",
+        "@ruby/prism": "^1.9.0"
       }
     },
     "node_modules/@herb-tools/printer": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/printer/-/printer-0.10.2.tgz",
-      "integrity": "sha512-xFMtZg+fY/+/uSgGRL+gC0J0bi690EPKg6sz0fc+HmEkLZFs1gB5sK4BZ0aiYu1kvQQ0E2e6G52Ic1huKi0fsQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/printer/-/printer-0.10.3.tgz",
+      "integrity": "sha512-OuuIisERq3TLnms/Wm5N6w/ITYqlBPPLsc1FNHdN3qedPOA/ey1dF2rKewUzQAsAZheRCs5nem7tDYRhPb2D/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@herb-tools/core": "0.10.2",
+        "@herb-tools/core": "0.10.3",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -88,28 +93,29 @@
       }
     },
     "node_modules/@herb-tools/rewriter": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/rewriter/-/rewriter-0.10.2.tgz",
-      "integrity": "sha512-V2TmCHwZNt2o8GDnkkc/UTViJDX8vxjAMHNs7S5X1alZfB6Rc8hxLNAkEP0iAaoaGm7Dx6+ih2e/jfnAU6sS4g==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/rewriter/-/rewriter-0.10.3.tgz",
+      "integrity": "sha512-UsqWOJVcmB7lptLtjUeFpVvOn44LFae+I44p5ixQ9nDLNnZiN/2+R52tJmVLOWijQORvtMInCWOHrSvXF6Bf/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@herb-tools/core": "0.10.2",
-        "@herb-tools/tailwind-class-sorter": "0.10.2",
+        "@herb-tools/core": "0.10.3",
+        "@herb-tools/tailwind-class-sorter": "0.10.3",
+        "@ruby/prism": "^1.9.0",
         "tinyglobby": "^0.2.15"
       }
     },
     "node_modules/@herb-tools/tailwind-class-sorter": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@herb-tools/tailwind-class-sorter/-/tailwind-class-sorter-0.10.2.tgz",
-      "integrity": "sha512-4LQKxfNB0Xem8iMZHOWVMs21YOj8Onqq3kMepcI7Aafoua7k7hdR4aUEfX6+SXCWPXZbCJxVqfsEjz/PRZfu9A==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/tailwind-class-sorter/-/tailwind-class-sorter-0.10.3.tgz",
+      "integrity": "sha512-KAowwSS6NmcRTQrQ591DR6dGI675KB0o/yxZt113BNDWiBB+bl4xdnd3hT19JV6Jsh3sS/0e90hYGUj/6PBW0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "clear-module": "^4.1.3",
         "escalade": "^3.2.0",
         "jiti": "^2.7.0",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.18",
         "postcss-import": "^16.1.1"
       },
       "engines": {
@@ -118,6 +124,13 @@
       "peerDependencies": {
         "tailwindcss": "^3.0 || ^4.0"
       }
+    },
+    "node_modules/@ruby/prism": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@ruby/prism/-/prism-1.9.0.tgz",
+      "integrity": "sha512-/j+JfP1eA0nCjx6c/8L6K/ENErmsqc6RMAba8rKYNz4RadrT7AW20u4WrjpWYWzdlk6k1YWHxoW9OS68w02+Vw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -234,9 +247,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -303,9 +316,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -323,7 +336,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -332,9 +345,9 @@
       }
     },
     "node_modules/postcss-import": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
-      "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.2.0.tgz",
+      "integrity": "sha512-0mQUGlSp87Zl70K58RNwQAN1WS9plFE6KWGui9nyK6ninduMyjW/Khaoy/BpBoFTBh7ndAvAKrSKVbwy6vd/BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "little-rock",
   "private": true,
   "devDependencies": {
-    "@herb-tools/linter": "^0.10.2"
+    "@herb-tools/linter": "^0.10.3"
   }
 }

--- a/test/helpers/todos_helper_test.rb
+++ b/test/helpers/todos_helper_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class TodosHelperTest < ActionView::TestCase
+  class TodoDescription < ActionView::TestCase
+    test "transaction: joins the note and the uncategorized amount" do
+      transaction = transactions(:debit_grocery)
+      item = Todo::Item.new(:transaction, transaction.booked_at, transaction)
+
+      formatted_amount = number_to_currency(transaction.uncategorized_amount)
+
+      assert_equal "#{transaction.note} #{formatted_amount}", todo_description(item)
+    end
+
+    test "account: returns the account's name" do
+      account = accounts(:checking)
+      item = Todo::Item.new(:account, account.created_at, account)
+
+      assert_equal account.name, todo_description(item)
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,77 +2,87 @@
 # yarn lockfile v1
 
 
-"@herb-tools/config@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/config/-/config-0.10.2.tgz#b2f3b20dcce7315463b7b2ef41879be9b58c7565"
-  integrity sha512-hNyNpspNoeiwO7VEorXrr827byq8hCMk6jP24X5d/RAVoVlzlRssqux5zDu3d8MG69J+Zb4EN3hkPDiVhkkELw==
+"@herb-tools/config@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/config/-/config-0.10.3.tgz#d6fbb2bb71d1c1679ed196f027378555b52e1979"
+  integrity sha512-cSaOwuWnij1wiB4Xh9Zfx/s+lhis7cN/+PXssanT/mXQLSRU2QeYasivyCQ1tRnpIVdGGOC/rqHVJQeNmj4pqg==
   dependencies:
-    "@herb-tools/core" "0.10.2"
+    "@herb-tools/core" "0.10.3"
     picomatch "^4.0.5"
     tinyglobby "^0.2.16"
     yaml "^2.9.0"
 
-"@herb-tools/core@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.10.2.tgz#0b76de5746a28f8bd6fdb5d0f0e0ce0c56e88760"
-  integrity sha512-gAZjcgFO0UcQXiRG1hkPAnn6SAX/Jj//Bq2QcFUCLMcbAY0uaF13g7QDiY+ntg9LqmdT5Lka0TXC8mv1ehTk8w==
-
-"@herb-tools/highlighter@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/highlighter/-/highlighter-0.10.2.tgz#c13a61c73e7a653e8ed97fd0b3bad1f2525a04b4"
-  integrity sha512-dO73MHogYflARek8PZQ/TYCkIeXxB353/KA+/w0fPf18jmNGVpHc6J1hC+Lsqo+k4runjCmvaPLN7ETWoI/ndA==
+"@herb-tools/core@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.10.3.tgz#03b1bf1a5d0c5acf9841209cf0c26dae3e2d85bb"
+  integrity sha512-rtDoh6C/EMYLEtFwYpuY+IlnV7PLsF5hQszq7uMDE/bwEpLVBlPFd2Wlk9E0RB31PVQKV1MwgGqstte87XqF9g==
   dependencies:
-    "@herb-tools/core" "0.10.2"
-    "@herb-tools/node-wasm" "0.10.2"
+    "@ruby/prism" "^1.9.0"
 
-"@herb-tools/linter@^0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/linter/-/linter-0.10.2.tgz#51a8a350b47e3e6c8a7a679eabbc196e3bfaf6c8"
-  integrity sha512-0B8kT3jrSJwwmjjW0IFOreloF/9yrGm9ti931TxVG54u0PYDNI8ONRLub0sSzbPlKqPFtJXhjN7lPRqQdGz3Ow==
+"@herb-tools/highlighter@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/highlighter/-/highlighter-0.10.3.tgz#f4b1dfb770e32055a778c4f44847111387efe98c"
+  integrity sha512-vyBPl/oWalPcXrhni6RrQzeizzC0i7An3yMAg/Xx+4HDhgU/zOlRqSUYLU7SpzjfK4OU5QhRDdc3OBI8dT5qmg==
   dependencies:
-    "@herb-tools/config" "0.10.2"
-    "@herb-tools/core" "0.10.2"
-    "@herb-tools/highlighter" "0.10.2"
-    "@herb-tools/node-wasm" "0.10.2"
-    "@herb-tools/printer" "0.10.2"
-    "@herb-tools/rewriter" "0.10.2"
+    "@herb-tools/core" "0.10.3"
+    "@herb-tools/node-wasm" "0.10.3"
+
+"@herb-tools/linter@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/linter/-/linter-0.10.3.tgz#cc39050466f43d2e196286e2bcb7a1a0aab99077"
+  integrity sha512-uNwJZkzswJ/IcpsjbuEzOXQQcfc40KGy8Ao1L69na2J6H7b4LFig2OIZ22vJasGdv4jODWJWnMDozRvWuv1vFA==
+  dependencies:
+    "@herb-tools/config" "0.10.3"
+    "@herb-tools/core" "0.10.3"
+    "@herb-tools/highlighter" "0.10.3"
+    "@herb-tools/node-wasm" "0.10.3"
+    "@herb-tools/printer" "0.10.3"
+    "@herb-tools/rewriter" "0.10.3"
+    "@ruby/prism" "^1.9.0"
     picomatch "^4.0.5"
     tinyglobby "^0.2.15"
 
-"@herb-tools/node-wasm@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/node-wasm/-/node-wasm-0.10.2.tgz#66c1a76fdedcba37ab49d4427875ae76e5adeb92"
-  integrity sha512-gSu674UiuxCL5ypQveQqGd4GMk+iKSmI7Hk2nLIs/L132exrfumVg+Jxd+Nqg6z7lzDbx+/yXLKdMoLIh1OFaw==
+"@herb-tools/node-wasm@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/node-wasm/-/node-wasm-0.10.3.tgz#dc1527c2af245f67dbe85e3ba3782aefafc70653"
+  integrity sha512-KUwHUMB6kluyvRiW0A9wbTiuO/qlvXLlSAnewmH2za7yePvYRSiThfAZEmXPqEmpmMRcIksFxaNaxUc6nBqyuA==
   dependencies:
-    "@herb-tools/core" "0.10.2"
+    "@herb-tools/core" "0.10.3"
+    "@ruby/prism" "^1.9.0"
 
-"@herb-tools/printer@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/printer/-/printer-0.10.2.tgz#53ca5098834abc6d0b6b93b81607f10418aacdab"
-  integrity sha512-xFMtZg+fY/+/uSgGRL+gC0J0bi690EPKg6sz0fc+HmEkLZFs1gB5sK4BZ0aiYu1kvQQ0E2e6G52Ic1huKi0fsQ==
+"@herb-tools/printer@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/printer/-/printer-0.10.3.tgz#df067a71a1107329eb482092db4d300fe96998b1"
+  integrity sha512-OuuIisERq3TLnms/Wm5N6w/ITYqlBPPLsc1FNHdN3qedPOA/ey1dF2rKewUzQAsAZheRCs5nem7tDYRhPb2D/Q==
   dependencies:
-    "@herb-tools/core" "0.10.2"
+    "@herb-tools/core" "0.10.3"
     tinyglobby "^0.2.15"
 
-"@herb-tools/rewriter@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/rewriter/-/rewriter-0.10.2.tgz#04757cdf3789e706f3be07bb1bf76d0cf69ee273"
-  integrity sha512-V2TmCHwZNt2o8GDnkkc/UTViJDX8vxjAMHNs7S5X1alZfB6Rc8hxLNAkEP0iAaoaGm7Dx6+ih2e/jfnAU6sS4g==
+"@herb-tools/rewriter@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/rewriter/-/rewriter-0.10.3.tgz#54a7d41b58751cc32c9e1ac105e528a1530037da"
+  integrity sha512-UsqWOJVcmB7lptLtjUeFpVvOn44LFae+I44p5ixQ9nDLNnZiN/2+R52tJmVLOWijQORvtMInCWOHrSvXF6Bf/g==
   dependencies:
-    "@herb-tools/core" "0.10.2"
-    "@herb-tools/tailwind-class-sorter" "0.10.2"
+    "@herb-tools/core" "0.10.3"
+    "@herb-tools/tailwind-class-sorter" "0.10.3"
+    "@ruby/prism" "^1.9.0"
     tinyglobby "^0.2.15"
 
-"@herb-tools/tailwind-class-sorter@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@herb-tools/tailwind-class-sorter/-/tailwind-class-sorter-0.10.2.tgz#3da462744631ca66893f179ac6306cd38b2753b2"
-  integrity sha512-4LQKxfNB0Xem8iMZHOWVMs21YOj8Onqq3kMepcI7Aafoua7k7hdR4aUEfX6+SXCWPXZbCJxVqfsEjz/PRZfu9A==
+"@herb-tools/tailwind-class-sorter@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/tailwind-class-sorter/-/tailwind-class-sorter-0.10.3.tgz#9b552b45f749d2deb25e093afadf686bad279d62"
+  integrity sha512-KAowwSS6NmcRTQrQ591DR6dGI675KB0o/yxZt113BNDWiBB+bl4xdnd3hT19JV6Jsh3sS/0e90hYGUj/6PBW0g==
   dependencies:
     clear-module "^4.1.3"
     escalade "^3.2.0"
     jiti "^2.7.0"
-    postcss "^8.5.10"
+    postcss "^8.5.18"
     postcss-import "^16.1.1"
+
+"@ruby/prism@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ruby/prism/-/prism-1.9.0.tgz#064f599caf2288e8f0738875abbdd4bc4755df95"
+  integrity sha512-/j+JfP1eA0nCjx6c/8L6K/ENErmsqc6RMAba8rKYNz4RadrT7AW20u4WrjpWYWzdlk6k1YWHxoW9OS68w02+Vw==
 
 callsites@^3.1.0:
   version "3.1.0"
@@ -86,6 +96,11 @@ clear-module@^4.1.3:
   dependencies:
     parent-module "^2.0.0"
     resolve-from "^5.0.0"
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 escalade@^3.2.0:
   version "3.2.0"
@@ -102,29 +117,29 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
-  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
 is-core-module@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
-  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
   dependencies:
-    hasown "^2.0.2"
+    hasown "^2.0.3"
 
 jiti@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
   integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
 
-nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 parent-module@^2.0.0:
   version "2.0.0"
@@ -154,9 +169,9 @@ pify@^2.3.0:
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 postcss-import@^16.1.1:
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-16.1.1.tgz#cfbe79e6c9232b0dbbe1c18f35308825cfe8ff2a"
-  integrity sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-16.2.0.tgz#29e6873196d196578aafa135c440a2a856230583"
+  integrity sha512-0mQUGlSp87Zl70K58RNwQAN1WS9plFE6KWGui9nyK6ninduMyjW/Khaoy/BpBoFTBh7ndAvAKrSKVbwy6vd/BA==
   dependencies:
     postcss-value-parser "^4.0.0"
     read-cache "^1.0.0"
@@ -167,12 +182,12 @@ postcss-value-parser@^4.0.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.5.10:
-  version "8.5.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.14.tgz#a66c2d7808fadf69ebb5b84a03f8bafd76c4919c"
-  integrity sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==
+postcss@^8.5.18:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -189,10 +204,11 @@ resolve-from@^5.0.0:
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve@^1.1.7:
-  version "1.22.11"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.11.tgz#aad857ce1ffb8bfa9b0b1ac29f1156383f68c262"
-  integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
   dependencies:
+    es-errors "^1.3.0"
     is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
@@ -208,9 +224,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tinyglobby@^0.2.15, tinyglobby@^0.2.16:
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
-  integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"


### PR DESCRIPTION
Updates all Ruby gems and the single JavaScript dependency (`@herb-tools/linter`) to their latest versions.

Key Ruby bumps: `solid_queue` 1.4.0→1.6.0, `redis-client` 0.26.4→0.30.1, `rubocop` 1.88.2→1.89.0, `herb` 0.10.2→0.10.3, plus `appkit` and `mvpa-css` refreshed to latest commits. The `solid_queue` 1.5.x upgrade changes recurring schedule time-zone interpretation to use the app's configured time zone (UTC) instead of the system local time — no impact since `config.time_zone` is unset.

JavaScript: `@herb-tools/linter` 0.10.2→0.10.3 with 34 new lint rules enabled; 3 rules (`actionview-no-silent-helper`, `erb-no-output-in-attribute-name`, `erb-prefer-direct-output`) are disabled pending fixes in a follow-up.

All 627 tests pass; RuboCop, Brakeman, bundler-audit, and herb linter all green.