### PR TITLE
Only let signed-in people open a live connection

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,14 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    include Appkit::Authentication::SessionLookup
+
+    identified_by :current_user
+
+    def connect
+      session = find_session_by_cookie
+      reject_unauthorized_connection unless session
+
+      self.current_user = session.user
+    end
   end
 end

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,11 +1,22 @@
 require "test_helper"
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
-  # test "connects with cookies" do
-  #   cookies.signed[:user_id] = 42
-  #
-  #   connect
-  #
-  #   assert_equal connection.user_id, "42"
-  # end
+  test "someone signed in is recognised on the live connection" do
+    session = sessions(:member_session)
+    cookies.signed[:session_token] = session.token
+
+    connect
+
+    assert_equal session.user, connection.current_user
+  end
+
+  test "someone who is not signed in is refused a live connection" do
+    assert_reject_connection { connect }
+  end
+
+  test "a session token that belongs to nobody is refused" do
+    cookies.signed[:session_token] = "not-a-real-token"
+
+    assert_reject_connection { connect }
+  end
 end


### PR DESCRIPTION
## What changes

A live connection now belongs to a signed-in person. Before, it belonged to anyone who asked.

```ruby
module ApplicationCable
  class Connection < ActionCable::Connection::Base
    include Appkit::Authentication::SessionLookup

    identified_by :current_user

    def connect
      session = find_session_by_cookie
      reject_unauthorized_connection unless session

      self.current_user = session.user
    end
  end
end
```

## Why now, when nothing streams yet

`ApplicationCable::Connection` was the empty class the generator leaves behind — no `identified_by`, no rejection. Nothing subscribes today, so there is no live exposure. But the moment anyone adds a single `turbo_stream_from` to a view, that stream would have been readable by any connection at all, signed in or not, and it would have looked like it was working. This is the piece that is easy to forget precisely because the feature appears to function without it.

Doing it now means the first stream is a one-liner in a view and cannot land unauthenticated.

## Reusing the existing definition of a session

The lookup is appkit's own `find_session_by_cookie`, not a hand-written `Session.find_by(token: cookies.signed[:session_token])`. Signing in over the web and opening a live connection therefore cannot drift apart on what counts as a session — including the expiry rules in `Appkit::SessionBehavior`.

## Tests

Written first, and the red was the right red:

```
Expected to reject connection but no rejection was made.        (no session)
Expected to reject connection but no rejection was made.        (unknown token)
NoMethodError: undefined method 'current_user'                  (nobody identified)
```

Three cases now covered — recognised when signed in, refused with no session, refused with a token belonging to nobody. They replace the commented-out example the generator left in that file, which the playbook counts as a stale liability.

634 tests green.

## Scope

Independent of #296 and #299 — this holds whichever cable adapter is in use, so it is based on `main` and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
